### PR TITLE
Add pre, post hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jin-frame",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jin-frame",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Reusable HTTP API request definition library",
   "scripts": {
     "debug": "node --inspect-brk -r ts-node/register ./node_modules/jest/bin/jest --no-cache --runInBand --detectOpenHandles",

--- a/src/__tests__/body.array.builder.test.ts
+++ b/src/__tests__/body.array.builder.test.ts
@@ -12,7 +12,12 @@ class Test001PostFrame extends JinEitherFrame {
   @JinEitherFrame.body()
   public readonly password!: string;
 
-  constructor(args: OmitConstructorType<Test001PostFrame, 'host' | 'method' | 'contentType'>) {
+  constructor(
+    args: OmitConstructorType<
+      Test001PostFrame,
+      'host' | 'method' | 'contentType' | 'query' | 'body' | 'header' | 'param'
+    >,
+  ) {
     super({
       host: 'http://some.api.google.com/jinframe/:passing',
       method: 'POST',

--- a/src/__tests__/header.builder.test.ts
+++ b/src/__tests__/header.builder.test.ts
@@ -39,6 +39,17 @@ test('T001-primitive-type', async () => {
   expect(req).toEqual(excpetation);
 });
 
+test('T001-header', async () => {
+  const frame = new Test001PostFrame({ passing: 'hello', username: 'ironman', password: 'advengers' });
+  frame.request();
+
+  expect(frame.header).toMatchObject({
+    username: 'ironman',
+    password: 'advengers',
+    'Content-Type': 'application/json',
+  });
+});
+
 class Test002PostFrame extends JinEitherFrame {
   @JinEitherFrame.param()
   public readonly passing: string;

--- a/src/__tests__/jinframe.get.test.ts
+++ b/src/__tests__/jinframe.get.test.ts
@@ -1,7 +1,8 @@
+/* eslint-disable no-console */
 /* eslint-disable max-classes-per-file */
 
 import { JinEitherFrame } from '@frames/JinEitherFrame';
-import axios from 'axios';
+import axios, { type AxiosRequestConfig } from 'axios';
 import { isPass } from 'my-only-either';
 import nock from 'nock';
 
@@ -21,6 +22,16 @@ class TestGetFrame extends JinEitherFrame {
     this.passing = 'pass';
     this.name = 'ironman';
     this.skill = ['beam', 'flying!'];
+  }
+
+  override preHook(req: AxiosRequestConfig<any>): void {
+    console.log(this);
+    console.log(req);
+  }
+
+  override postHook(req: AxiosRequestConfig<any>): void {
+    console.log(this);
+    console.log(req);
   }
 }
 

--- a/src/frames/JinFrame.ts
+++ b/src/frames/JinFrame.ts
@@ -98,6 +98,8 @@ export class JinFrame<TPASS = unknown, TFAIL = TPASS>
       };
 
       try {
+        this.preHook?.(req);
+
         const reply = await axios.request<TPASS, AxiosResponse<TPASS>, TFAIL>(req);
 
         if (isValidateStatus(reply.status) === false) {
@@ -111,10 +113,14 @@ export class JinFrame<TPASS = unknown, TFAIL = TPASS>
             message: 'response error',
           });
 
+          this.postHook?.(req, err);
+
           throw err;
         }
 
         const duration = getDuration(this.startAt, new Date());
+
+        this.postHook?.(req);
 
         return {
           ...reply,

--- a/src/frames/__tests__/jin.either.frame.test.ts
+++ b/src/frames/__tests__/jin.either.frame.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import { JinEitherFrame } from '@frames/JinEitherFrame';
-import type { OmitConstructorType } from '@tools/ConstructorType';
+import type { JinBuiltInMember, OmitConstructorType } from '@tools/ConstructorType';
 import 'jest';
 import nock from 'nock';
 
@@ -14,7 +14,7 @@ class Test001PostFrame extends JinEitherFrame {
   @JinEitherFrame.body()
   public readonly password!: string;
 
-  constructor(args: OmitConstructorType<Test001PostFrame, 'host' | 'method' | 'contentType'>) {
+  constructor(args: OmitConstructorType<Test001PostFrame, JinBuiltInMember>) {
     super({
       host: 'http://some.api.google.com/jinframe/:passing',
       method: 'post',
@@ -33,7 +33,7 @@ class Test002PostFrame extends JinEitherFrame {
   @JinEitherFrame.body()
   public readonly password!: string;
 
-  constructor(args: OmitConstructorType<Test002PostFrame, 'host' | 'method' | 'contentType'>) {
+  constructor(args: OmitConstructorType<Test002PostFrame, JinBuiltInMember>) {
     super({
       host: 'http://some.api.google.com/jinframe/:passing/:raiseerr',
       method: 'post',

--- a/src/frames/__tests__/jin.frame.test.ts
+++ b/src/frames/__tests__/jin.frame.test.ts
@@ -2,7 +2,7 @@
 import { JinCreateError } from '@frames/JinCreateError';
 import { JinFrame } from '@frames/JinFrame';
 import type { JinRequestError } from '@frames/JinRequestError';
-import type { OmitConstructorType } from '@tools/ConstructorType';
+import type { JinBuiltInMember, OmitConstructorType } from '@tools/ConstructorType';
 import 'jest';
 import nock from 'nock';
 
@@ -28,7 +28,7 @@ class Test001PostFrame extends JinFrame<{ message: string }> {
   @JinFrame.body()
   public readonly password!: string;
 
-  constructor(args: OmitConstructorType<Test001PostFrame, 'host' | 'method' | 'contentType'>) {
+  constructor(args: OmitConstructorType<Test001PostFrame, JinBuiltInMember>) {
     super({
       host: 'http://some.api.google.com/jinframe/:passing',
       method: 'post',
@@ -47,7 +47,7 @@ class Test002PostFrame extends JinFrame<{ message: string }> {
   @JinFrame.body()
   public readonly password!: string;
 
-  constructor(args: OmitConstructorType<Test001PostFrame, 'host' | 'method' | 'contentType'>) {
+  constructor(args: OmitConstructorType<Test001PostFrame, JinBuiltInMember>) {
     super({
       host: 'http://some.api.google.com/jinframe/:passing/:raiseerr',
       method: 'post',

--- a/src/tools/ConstructorType.ts
+++ b/src/tools/ConstructorType.ts
@@ -20,12 +20,24 @@ export type ConstructorType<T> = OmitType<T, Function>;
 
 export type OmitConstructorType<T, M extends keyof ConstructorType<T>> = Omit<ConstructorType<T>, M>;
 
-export type JinConstructorType<T extends AbstractJinFrame> = Omit<
-  ConstructorType<T>,
-  'host' | 'path' | 'method' | 'contentType' | 'customBody'
+export type JinBuiltInMember = Extract<
+  keyof AbstractJinFrame,
+  | 'host'
+  | 'path'
+  | 'method'
+  | 'contentType'
+  | 'customBody'
+  | 'preHook'
+  | 'postHook'
+  | 'query'
+  | 'header'
+  | 'param'
+  | 'body'
 >;
+
+export type JinConstructorType<T extends AbstractJinFrame> = Omit<ConstructorType<T>, JinBuiltInMember>;
 
 export type JinOmitConstructorType<T extends AbstractJinFrame, M extends keyof ConstructorType<T>> = Omit<
   ConstructorType<T>,
-  'host' | 'path' | 'method' | 'contentType' | 'customBody' | M
+  JinBuiltInMember | M
 >;


### PR DESCRIPTION
* add pre, post hook
  * `AbstractJinFrame` interface implement: preHook, postHook function execute will axoios.request function before(preHook) and after(postHook)
* add query, header, body, param getter
  * for logging, debugging
  * request function build each request parameter and store private class member variable
* migrate testcase
* version change
  * 3.3.1 > 3.4.0