### PR TITLE
Change constructor interface in AbstractJinFrame, JinEitherFrame, Jin…

### DIFF
--- a/src/__tests__/body.array.builder.test.ts
+++ b/src/__tests__/body.array.builder.test.ts
@@ -1,4 +1,5 @@
 import { JinEitherFrame } from '#frames/JinEitherFrame';
+import type JinBuiltInMember from '#tools/type-utilities/JinBuiltInMember';
 import type OmitConstructorType from '#tools/type-utilities/OmitConstructorType';
 
 class Test001PostFrame extends JinEitherFrame {
@@ -11,16 +12,11 @@ class Test001PostFrame extends JinEitherFrame {
   @JinEitherFrame.body()
   public readonly password!: string;
 
-  constructor(
-    args: OmitConstructorType<
-      Test001PostFrame,
-      'host' | 'method' | 'contentType' | '$$query' | '$$body' | '$$header' | '$$param'
-    >,
-  ) {
+  constructor(args: OmitConstructorType<Test001PostFrame, JinBuiltInMember>) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -65,9 +61,9 @@ class Test002PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; username2: string[]; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }

--- a/src/__tests__/body.builder.test.ts
+++ b/src/__tests__/body.builder.test.ts
@@ -12,9 +12,9 @@ class Test001PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -48,9 +48,9 @@ class Test002PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -84,9 +84,9 @@ class Test003PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -134,9 +134,9 @@ class Test004ZeroDepthPostFrame extends JinEitherFrame {
     };
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }

--- a/src/__tests__/body.formatter.builder.test.ts
+++ b/src/__tests__/body.formatter.builder.test.ts
@@ -17,8 +17,8 @@ class Test001PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -66,8 +66,8 @@ class Test002PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -122,8 +122,8 @@ class Test003PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; password: string; today: Date }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -188,8 +188,8 @@ class Test004PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; password: string; today: Date }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -255,8 +255,8 @@ class Test005PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; password: string; today: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -324,8 +324,8 @@ class Test006PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; password: string; today: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;

--- a/src/__tests__/body.formatters.builder.test.ts
+++ b/src/__tests__/body.formatters.builder.test.ts
@@ -15,8 +15,8 @@ class Test001PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string[]; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -87,8 +87,8 @@ class Test002PostFrame extends JinEitherFrame {
     password: string;
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -26,8 +26,8 @@ class PokemonPagingFrame extends JinEitherFrame<any, any> {
 
   constructor(args: JinConstructorType<PokemonPagingFrame>) {
     super({
-      host: 'https://pokeapi.co/api/v2/pokemon',
-      method: 'GET',
+      $$host: 'https://pokeapi.co/api/v2/pokemon',
+      $$method: 'GET',
     });
 
     this.limit = args.limit;

--- a/src/__tests__/fileupload.test.ts
+++ b/src/__tests__/fileupload.test.ts
@@ -16,11 +16,11 @@ class TestGetFrame extends JinEitherFrame {
 
   constructor(args: { description: string; file: JinFile<Buffer>; files: JinFile<Buffer>[] }) {
     super({
-      host: 'http://some.api.google.com',
-      path: '/fileupload-case04',
-      method: 'post',
-      contentType: 'multipart/form-data',
       ...args,
+      $$host: 'http://some.api.google.com',
+      $$path: '/fileupload-case04',
+      $$method: 'post',
+      $$contentType: 'multipart/form-data',
     });
   }
 }

--- a/src/__tests__/header.builder.test.ts
+++ b/src/__tests__/header.builder.test.ts
@@ -2,23 +2,20 @@ import { JinEitherFrame } from '#frames/JinEitherFrame';
 
 class Test001PostFrame extends JinEitherFrame {
   @JinEitherFrame.param()
-  public readonly passing: string;
+  public readonly passing!: string;
 
   @JinEitherFrame.H()
-  public readonly username: string;
+  public readonly username!: string;
 
   @JinEitherFrame.H()
-  public readonly password: string;
+  public readonly password!: string;
 
   constructor(args: { passing: string; username: string; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
-
-    this.passing = args.passing;
-    this.username = args.username;
-    this.password = args.password;
   }
 }
 
@@ -51,23 +48,20 @@ test('T001-header', async () => {
 
 class Test002PostFrame extends JinEitherFrame {
   @JinEitherFrame.param()
-  public readonly passing: string;
+  public readonly passing!: string;
 
   @JinEitherFrame.header({ replaceAt: 'uuu' })
-  public readonly username: string;
+  public readonly username!: string;
 
   @JinEitherFrame.header({ replaceAt: 'ppp' })
-  public readonly password: string;
+  public readonly password!: string;
 
   constructor(args: { passing: string; username: string; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
-
-    this.passing = args.passing;
-    this.username = args.username;
-    this.password = args.password;
   }
 }
 
@@ -89,23 +83,20 @@ test('T002-primitive-type-key-replace', async () => {
 
 class Test003PostFrame extends JinEitherFrame {
   @JinEitherFrame.param()
-  public readonly passing: string;
+  public readonly passing!: string;
 
   @JinEitherFrame.header({ replaceAt: 'uuu.username' })
-  public readonly username: string;
+  public readonly username!: string;
 
   @JinEitherFrame.header({ replaceAt: 'ppp.password' })
-  public readonly password: string;
+  public readonly password!: string;
 
   constructor(args: { passing: string; username: string; password: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
-
-    this.passing = args.passing;
-    this.username = args.username;
-    this.password = args.password;
   }
 }
 
@@ -129,13 +120,13 @@ test('T003-primitive-type-key-replace-at-not-support-dot-props', async () => {
 
 class Test004PostFrame extends JinEitherFrame {
   @JinEitherFrame.param()
-  public readonly passing: string;
+  public readonly passing!: string;
 
   @JinEitherFrame.header()
-  public readonly username: string;
+  public readonly username!: string;
 
   @JinEitherFrame.header()
-  public readonly hero: {
+  public readonly hero!: {
     name: string;
     ability: string;
     age: number;
@@ -151,13 +142,10 @@ class Test004PostFrame extends JinEitherFrame {
     };
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
-
-    this.passing = args.passing;
-    this.username = args.username;
-    this.hero = args.hero;
   }
 }
 
@@ -190,23 +178,20 @@ test('T004-plain-object-type-json-serialization', async () => {
 
 class Test005PostFrame extends JinEitherFrame {
   @JinEitherFrame.param()
-  public readonly passing: string;
+  public readonly passing!: string;
 
   @JinEitherFrame.header()
-  public readonly username: string;
+  public readonly username!: string;
 
   @JinEitherFrame.header({ comma: true, encode: false })
-  public readonly hero: string[];
+  public readonly hero!: string[];
 
   constructor(args: { passing: string; username: string; hero: string[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
-
-    this.passing = args.passing;
-    this.username = args.username;
-    this.hero = args.hero;
   }
 }
 

--- a/src/__tests__/header.formatter.test.ts
+++ b/src/__tests__/header.formatter.test.ts
@@ -19,9 +19,9 @@ class Test001PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string; sendAt: Date }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -67,8 +67,8 @@ class Test002PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string; sendAt: Date[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -121,8 +121,8 @@ class Test003PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string; sendAt: string[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -180,8 +180,8 @@ class Test004PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; username: string; sendAt: number[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;

--- a/src/__tests__/ignore.host.test.ts
+++ b/src/__tests__/ignore.host.test.ts
@@ -11,7 +11,7 @@ class TestGet2Frame extends JinEitherFrame {
   public readonly ttt: string;
 
   constructor() {
-    super({ path: '/jinframe/:passing/test', method: 'get' });
+    super({ $$path: '/jinframe/:passing/test', $$method: 'get' });
 
     this.passing = 'hello';
     this.name = 'ironman';

--- a/src/__tests__/jinframe.get.test.ts
+++ b/src/__tests__/jinframe.get.test.ts
@@ -19,7 +19,7 @@ class TestGetFrame extends JinEitherFrame {
   public readonly skill: string[];
 
   constructor() {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'get' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'get' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -58,7 +58,7 @@ class TestGet2Frame extends JinEitherFrame {
   }
 
   constructor(host: string) {
-    super({ host, path: '/jinframe/:passing/test', method: 'get' });
+    super({ $$host: host, $$path: '/jinframe/:passing/test', $$method: 'get' });
 
     this.passing = 'hello';
     this.name = 'ironman';
@@ -77,7 +77,7 @@ class TestGet3Frame extends JinFrame {
   public readonly skill: string[];
 
   constructor() {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'get' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'get' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -108,7 +108,7 @@ class TestGet4Frame extends JinFrame {
   public readonly skill: string[];
 
   constructor() {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'get' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'get' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -136,7 +136,7 @@ class TestGet5Frame extends JinFrame {
   public readonly skill: string[];
 
   constructor() {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'get' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'get' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -159,7 +159,7 @@ class TestGet6Frame extends JinFrame {
   public readonly skill: string[];
 
   constructor() {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'get' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'get' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -182,7 +182,7 @@ class TestGet7Frame extends JinEitherFrame {
   public readonly skill: string[];
 
   constructor() {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'get' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'get' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -205,7 +205,7 @@ class TestGet8Frame extends JinEitherFrame {
   public readonly skill: string[];
 
   constructor() {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'get' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'get' });
 
     this.passing = 'pass';
     this.name = 'ironman';

--- a/src/__tests__/jinframe.post.test.ts
+++ b/src/__tests__/jinframe.post.test.ts
@@ -16,7 +16,7 @@ class TestPostFrame extends JinEitherFrame {
   public readonly gender: string;
 
   constructor() {
-    super({ host: 'http://some.api.google.com/jinframe/:passing', method: 'POST' });
+    super({ $$host: 'http://some.api.google.com/jinframe/:passing', $$method: 'POST' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -37,9 +37,9 @@ class TestUrlencodedPostFrame extends JinEitherFrame {
 
   constructor() {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      contentType: 'application/x-www-form-urlencoded',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$contentType: 'application/x-www-form-urlencoded',
+      $$method: 'POST',
     });
 
     this.passing = 'pass';

--- a/src/__tests__/object.body.array.builder.test.ts
+++ b/src/__tests__/object.body.array.builder.test.ts
@@ -18,9 +18,9 @@ class Test001PostFrame extends JinEitherFrame {
     ability: { name: string; skill: string; count: number; category: { name: string } }[];
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -95,9 +95,9 @@ class Test002PostFrame extends JinEitherFrame {
     ability: { name: string; skill: string; count: number; category: { name: string; developAt: Date } }[];
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -159,9 +159,9 @@ class Test003PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: string[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -203,9 +203,9 @@ class Test004PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: Date[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -257,9 +257,9 @@ class Test005PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: Date[]; birthAt: Date[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -308,9 +308,9 @@ class Test006PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: string[]; birthAt: Date[] }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }
@@ -377,9 +377,9 @@ class Test007PostFrame extends JinEitherFrame {
     birthAt: Date[];
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
   }
 }

--- a/src/__tests__/object.body.builder.test.ts
+++ b/src/__tests__/object.body.builder.test.ts
@@ -21,8 +21,8 @@ class Test001PostFrame extends JinEitherFrame {
     hero: { name: string; age: number; bio: { birth: string } };
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -84,8 +84,8 @@ class Test002PostFrame extends JinEitherFrame {
     ability: { skill: string; count: number; category: { name: string } };
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -159,8 +159,8 @@ class Test003PostFrame extends JinEitherFrame {
     ability: { skill: string; count: number; category: { name: string; developAt: Date } };
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -240,8 +240,8 @@ class Test004PostFrame extends JinEitherFrame {
     ability: { name: string; skill: string; count: number; category: { name: string; developAt: Date } };
   }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;

--- a/src/__tests__/object.body.primitive.builder.test.ts
+++ b/src/__tests__/object.body.primitive.builder.test.ts
@@ -10,8 +10,8 @@ class Test001PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: number }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -50,8 +50,8 @@ class Test002PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: string }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -95,8 +95,8 @@ class Test003PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: Date }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;
@@ -136,8 +136,8 @@ class Test004PostFrame extends JinEitherFrame {
 
   constructor(args: { passing: string; ability: boolean }) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'POST',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'POST',
     });
 
     this.passing = args.passing;

--- a/src/__tests__/overlap.get.ts
+++ b/src/__tests__/overlap.get.ts
@@ -15,7 +15,7 @@ class TestGetFrame extends JinEitherFrame {
   public readonly skills!: string[];
 
   constructor(args: { id: string; name: string; skills: string[] }) {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:id', method: 'post', ...args });
+    super({ ...args, $$host: 'http://some.api.google.com', $$path: '/jinframe/:id', $$method: 'post' });
   }
 }
 

--- a/src/__tests__/request.body.ts
+++ b/src/__tests__/request.body.ts
@@ -93,7 +93,7 @@ class Test001PostFrame extends JinEitherFrame {
   public readonly multipleFormatting: IFirstBody;
 
   constructor({ multipleFormatting }: { multipleFormatting: IFirstBody }) {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'POST' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'POST' });
 
     this.passing = 'pass';
     this.name = 'ironman';
@@ -179,7 +179,7 @@ class Test002PostFrame extends JinEitherFrame {
     secondBody: ISecondBody;
     thirdBody: IThirdBody;
   }) {
-    super({ host: 'http://some.api.google.com', path: '/jinframe/:passing', method: 'POST' });
+    super({ $$host: 'http://some.api.google.com', $$path: '/jinframe/:passing', $$method: 'POST' });
 
     this.passing = 'pass';
     this.name = 'ironman';

--- a/src/frames/JinEitherFrame.ts
+++ b/src/frames/JinEitherFrame.ts
@@ -60,7 +60,13 @@ export class JinEitherFrame<TPASS = unknown, TFAIL = TPASS>
    * @param __namedParameters.contentType - content-type of API Request endpoint
    * @param __namedParameters.customBody - custom object of POST Request body data
    */
-  constructor(args: { host?: string; path?: string; method: Method; contentType?: string; customBody?: unknown }) {
+  constructor(args: {
+    $$host?: string;
+    $$path?: string;
+    $$method: Method;
+    $$contentType?: string;
+    $$customBody?: unknown;
+  }) {
     super({ ...args });
   }
 

--- a/src/frames/JinFrame.ts
+++ b/src/frames/JinFrame.ts
@@ -60,7 +60,13 @@ export class JinFrame<TPASS = unknown, TFAIL = TPASS>
    * @param __namedParameters.contentType - content-type of API Request endpoint
    * @param __namedParameters.customBody - custom object of POST Request body data
    */
-  constructor(args: { host?: string; path?: string; method: Method; contentType?: string; customBody?: unknown }) {
+  constructor(args: {
+    $$host?: string;
+    $$path?: string;
+    $$method: Method;
+    $$contentType?: string;
+    $$customBody?: unknown;
+  }) {
     super({ ...args });
   }
 

--- a/src/frames/__tests__/abstract.frame.test.ts
+++ b/src/frames/__tests__/abstract.frame.test.ts
@@ -1,9 +1,6 @@
-/* eslint-disable max-classes-per-file */
 import { JinFile } from '#frames/JinFile';
 import { JinFrame } from '#frames/JinFrame';
-import type JinBuiltInMember from '#tools/type-utilities/JinBuiltInMember';
 import type { JinConstructorType } from '#tools/type-utilities/JinConstructorType';
-import type OmitConstructorType from '#tools/type-utilities/OmitConstructorType';
 import 'jest';
 import nock from 'nock';
 
@@ -19,10 +16,10 @@ class Test001PostFrame extends JinFrame<{ message: string }> {
 
   constructor(args: JinConstructorType<Test001PostFrame>) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      contentType: 'multipart/form-data',
-      method: 'post',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$contentType: 'multipart/form-data',
+      $$method: 'post',
     });
   }
 }
@@ -37,11 +34,12 @@ class Test002PostFrame extends JinFrame<{ message: string }> {
   @JinFrame.body()
   public readonly password!: string;
 
-  constructor(args: OmitConstructorType<Test002PostFrame, Exclude<JinBuiltInMember, 'contentType' | 'customBody'>>) {
+  constructor(args: JinConstructorType<Test002PostFrame>) {
     super({
       ...args,
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'post',
+      $$host: 'http://some.api.google.com',
+      $$path: '/jinframe/:passing',
+      $$method: 'post',
     });
   }
 }
@@ -56,9 +54,9 @@ class Test003PostFrame extends JinFrame<{ message: string }> {
   @JinFrame.body()
   public readonly password!: string;
 
-  constructor(args: OmitConstructorType<Test003PostFrame, Exclude<JinBuiltInMember, 'customBody'>>) {
+  constructor(args: JinConstructorType<Test003PostFrame>) {
     super({
-      method: 'post',
+      $$method: 'post',
       ...args,
     });
   }
@@ -76,9 +74,9 @@ class Test004PostFrame extends JinFrame<{ message: string }> {
 
   constructor(args: JinConstructorType<Test004PostFrame>) {
     super({
-      method: 'post',
-      host: 'http://some.api.google.com/jinframe/:passing',
       ...args,
+      $$method: 'post',
+      $$host: 'http://some.api.google.com/jinframe/:passing',
     });
   }
 }
@@ -114,7 +112,6 @@ describe('AbstractJinFrame', () => {
     frame.request();
 
     expect(frame.$$body).toMatchObject({ username: 'ironman', password: 'avengers' });
-
     expect(frame.$$param).toMatchObject({ passing: 'pass' });
   });
 
@@ -153,12 +150,17 @@ describe('AbstractJinFrame', () => {
       username: 'ironman',
       password: 'avengers',
       passing: 'pass',
-      contentType: 'application/json',
-      customBody: { sample: 'sample' },
+      $$contentType: 'application/json',
+      $$customBody: { sample: 'sample' },
     });
 
     const r = frame.request();
 
+    expect(frame.$$host).toEqual('http://some.api.google.com');
+    expect(frame.$$path).toEqual('/jinframe/:passing');
+    expect(frame.$$method).toEqual('post');
+    expect(frame.$$customBody).toMatchObject({ sample: 'sample' });
+    expect(frame.$$contentType).toEqual('application/json');
     expect(r.data).toMatchObject({
       sample: 'sample',
     });
@@ -170,7 +172,7 @@ describe('AbstractJinFrame', () => {
         username: 'ironman',
         password: 'avengers',
         passing: 'pass',
-        customBody: { sample: 'sample' },
+        $$customBody: { sample: 'sample' },
       });
 
       frame.request();
@@ -186,11 +188,12 @@ describe('AbstractJinFrame', () => {
       username: 'ironman',
       password: 'avengers',
       passing: 'pass',
-      contentType: 'application/x-www-form-urlencoded',
-      transformRequest: tr,
+      $$contentType: 'application/x-www-form-urlencoded',
+      $$transformRequest: tr,
     });
 
     const t = frame.getTransformRequest();
+    expect(frame.$$transformRequest).toBeTruthy();
     expect(t).toBe(tr);
   });
 

--- a/src/frames/__tests__/jin.either.frame.test.ts
+++ b/src/frames/__tests__/jin.either.frame.test.ts
@@ -17,9 +17,9 @@ class Test001PostFrame extends JinEitherFrame {
 
   constructor(args: OmitConstructorType<Test001PostFrame, JinBuiltInMember>) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'post',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'post',
     });
   }
 }
@@ -36,9 +36,9 @@ class Test002PostFrame extends JinEitherFrame {
 
   constructor(args: OmitConstructorType<Test002PostFrame, JinBuiltInMember>) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing/:raiseerr',
-      method: 'post',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing/:raiseerr',
+      $$method: 'post',
     });
   }
 }

--- a/src/frames/__tests__/jin.frame.test.ts
+++ b/src/frames/__tests__/jin.frame.test.ts
@@ -31,9 +31,9 @@ class Test001PostFrame extends JinFrame<{ message: string }> {
 
   constructor(args: OmitConstructorType<Test001PostFrame, JinBuiltInMember>) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing',
-      method: 'post',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing',
+      $$method: 'post',
     });
   }
 }
@@ -50,9 +50,9 @@ class Test002PostFrame extends JinFrame<{ message: string }> {
 
   constructor(args: OmitConstructorType<Test001PostFrame, JinBuiltInMember>) {
     super({
-      host: 'http://some.api.google.com/jinframe/:passing/:raiseerr',
-      method: 'post',
       ...args,
+      $$host: 'http://some.api.google.com/jinframe/:passing/:raiseerr',
+      $$method: 'post',
     });
   }
 }

--- a/src/tools/type-utilities/JinBuiltInMember.ts
+++ b/src/tools/type-utilities/JinBuiltInMember.ts
@@ -5,19 +5,21 @@
  */
 import type AbstractJinFrame from '#frames/AbstractJinFrame';
 
-type JinBuiltInMember = Extract<
-  keyof AbstractJinFrame,
-  | 'host'
-  | 'path'
-  | 'method'
-  | 'contentType'
-  | 'customBody'
-  | 'preHook'
-  | 'postHook'
-  | '$$query'
-  | '$$header'
-  | '$$param'
-  | '$$body'
->;
+type JinBuiltInMember =
+  | Extract<
+      keyof AbstractJinFrame,
+      | '$$query'
+      | '$$header'
+      | '$$param'
+      | '$$body'
+      | '$$host'
+      | '$$path'
+      | '$$method'
+      | '$$contentType'
+      | '$$customBody'
+      | '$$transformRequest'
+    >
+  | '$$preHook'
+  | '$$postHook';
 
 export default JinBuiltInMember;

--- a/src/tools/type-utilities/JinConstructorType.ts
+++ b/src/tools/type-utilities/JinConstructorType.ts
@@ -6,5 +6,13 @@
 import type AbstractJinFrame from '#frames/AbstractJinFrame';
 import type ConstructorType from '#tools/type-utilities/ConstructorType';
 import type JinBuiltInMember from '#tools/type-utilities/JinBuiltInMember';
+import type { AxiosRequestConfig, Method } from 'axios';
 
-export type JinConstructorType<T extends AbstractJinFrame> = Omit<ConstructorType<T>, JinBuiltInMember>;
+export type JinConstructorType<T extends AbstractJinFrame> = Omit<ConstructorType<T>, JinBuiltInMember> & {
+  $$host?: string;
+  $$path?: string;
+  $$method?: Method;
+  $$contentType?: string;
+  $$customBody?: unknown;
+  $$transformRequest?: AxiosRequestConfig['transformRequest'];
+};

--- a/src/tools/type-utilities/JinOmitConstructorType.ts
+++ b/src/tools/type-utilities/JinOmitConstructorType.ts
@@ -5,9 +5,16 @@
  */
 import type AbstractJinFrame from '#frames/AbstractJinFrame';
 import type ConstructorType from '#tools/type-utilities/ConstructorType';
-import type JinBuiltInMember from '#tools/type-utilities/JinBuiltInMember';
+import type { AxiosRequestConfig, Method } from 'axios';
 
 export type JinOmitConstructorType<T extends AbstractJinFrame, M extends keyof ConstructorType<T>> = Omit<
-  ConstructorType<T>,
-  JinBuiltInMember | M
+  ConstructorType<T> & {
+    $$host?: string;
+    $$path?: string;
+    $$method?: Method;
+    $$contentType?: string;
+    $$customBody?: unknown;
+    $$transformRequest?: AxiosRequestConfig['transformRequest'];
+  },
+  M
 >;


### PR DESCRIPTION
…Frame

* change constructor interface in AbstractJinFrame, JinEitherFrame, JinFrame * as-is host, path, method, contentType, customBody, transformRequest, query, header, body, param * to-be $$host, $$path, $$method, $$contentType, $$customBody, $$transformRequest, $$query, $$header, $$body, $$param * this changing make that can be define built-in variable * eg. @JinFrame.query() host: string;
* migration testcase