### PR TITLE
Add new feature: Querystring, Path params can rename specific field

### DIFF
--- a/src/__tests__/jinframe.get.test.ts
+++ b/src/__tests__/jinframe.get.test.ts
@@ -12,7 +12,7 @@ class TestGetFrame extends JinEitherFrame {
   @JinEitherFrame.P()
   public readonly passing: string;
 
-  @JinEitherFrame.query()
+  @JinEitherFrame.Q({ replaceAt: 'myname' })
   public readonly name: string;
 
   @JinEitherFrame.query({ encode: true })
@@ -231,7 +231,7 @@ describe('jinframe.test', () => {
   });
 
   test('jin-either-frame', async () => {
-    nock('http://some.api.google.com').get('/jinframe/pass?name=ironman&skill=beam&skill=flying!').reply(200, {
+    nock('http://some.api.google.com').get('/jinframe/pass?myname=ironman&skill=beam&skill=flying!').reply(200, {
       message: 'hello',
     });
 
@@ -264,7 +264,7 @@ describe('jinframe.test', () => {
   });
 
   test('jin-either-frame post hook fail case', async () => {
-    nock('http://some.api.google.com').get('/jinframe/pass?name=ironman&skill=beam&skill=flying!').reply(400, {
+    nock('http://some.api.google.com').get('/jinframe/pass?myname=ironman&skill=beam&skill=flying!').reply(400, {
       message: 'hello',
     });
 

--- a/src/interfaces/IQueryParamCommonFieldOption.ts
+++ b/src/interfaces/IQueryParamCommonFieldOption.ts
@@ -1,8 +1,16 @@
-import type { ICommonFieldOption } from '#interfaces/ICommonFieldOption';
 import type { IFormatter } from '#interfaces/IFormatter';
 
-export interface IQueryParamCommonFieldOption extends ICommonFieldOption {
+export interface IQueryParamCommonFieldOption {
   formatter?: IFormatter;
+
+  /**
+   * If you want to create depth or rename on field of body
+   * set this option dot seperated string. See below,
+   *
+   * @example
+   * `data.test.ironman` convert to `{ "data.test.ironman": "value here" }`
+   */
+  replaceAt?: string;
 
   /**
    * "comma" option only working querystring. If you want to process array parameter of querystring

--- a/src/processors/getDefaultOption.ts
+++ b/src/processors/getDefaultOption.ts
@@ -16,6 +16,7 @@ export function getDefaultQueryFieldOption(
       enable: option?.bit?.enable ?? false,
       withZero: option?.bit?.withZero ?? false,
     },
+    replaceAt: option?.replaceAt,
     encode: option?.encode ?? true,
   };
 }
@@ -31,6 +32,7 @@ export function getDefaultParamFieldOption(
       enable: option?.bit?.enable ?? false,
       withZero: option?.bit?.withZero ?? false,
     },
+    replaceAt: option?.replaceAt,
     encode: option?.encode ?? true,
   };
 }

--- a/src/processors/getQueryParamInfo.ts
+++ b/src/processors/getQueryParamInfo.ts
@@ -17,9 +17,10 @@ export function getQueryParamInfo<T extends Record<string, unknown>>(
     try {
       const { key: thisFrameAccessKey, option } = field;
       const value: unknown = dotProp.get<unknown>(thisFrame, thisFrameAccessKey);
+      const fieldKey = option.replaceAt ?? thisFrameAccessKey;
 
       if (!isValidPrimitiveType(value) && !isValidArrayType(value)) {
-        return { ...resultObj, thisFrameAccessKey: value };
+        return { ...resultObj, [fieldKey]: value };
       }
 
       // stage 01. bit-wised operator processing
@@ -32,7 +33,7 @@ export function getQueryParamInfo<T extends Record<string, unknown>>(
         }
 
         // exclude zero value in bit value
-        return { ...resultObj, [thisFrameAccessKey]: encode(option.encode, bitwisedValue) };
+        return { ...resultObj, [fieldKey]: encode(option.encode, bitwisedValue) };
       }
 
       const { formatter } = option;
@@ -43,7 +44,7 @@ export function getQueryParamInfo<T extends Record<string, unknown>>(
         const commaApplied = Array.isArray(formatted) && option.comma ? formatted.join(',') : formatted;
         return {
           ...resultObj,
-          [thisFrameAccessKey]: Array.isArray(commaApplied)
+          [fieldKey]: Array.isArray(commaApplied)
             ? encodes(option.encode, commaApplied)
             : encode(option.encode, commaApplied),
         };
@@ -51,7 +52,7 @@ export function getQueryParamInfo<T extends Record<string, unknown>>(
 
       // stage 03. comma seperation processing
       const commaApplied = Array.isArray(value) && option.comma ? encode(option.encode, value.join(',')) : value;
-      return { ...resultObj, [thisFrameAccessKey]: commaApplied };
+      return { ...resultObj, [fieldKey]: commaApplied };
     } catch {
       return resultObj;
     }


### PR DESCRIPTION
- [add] Add new feature: rename field using `replaceAt` in Querystring, Path params
  - This can be used when you need to use built-in function names like `execute`, `create`, etc.