### PR TITLE
feat(qs): add new option keyFormat

### DIFF
--- a/src/__tests__/jinframe.get.test.ts
+++ b/src/__tests__/jinframe.get.test.ts
@@ -142,7 +142,7 @@ class TestGet5Frame extends JinFrame {
   @Query()
   declare public readonly name: string;
 
-  @Query({ encode: true })
+  @Query({ encode: false, keyForamt: 'indices' })
   declare public readonly skill: string[];
 
   constructor() {
@@ -166,7 +166,7 @@ class TestGet6Frame extends JinFrame {
   @Query()
   declare public readonly name: string;
 
-  @Query({ encode: true })
+  @Query({ encode: false, keyForamt: 'brackets' })
   declare public readonly skill: string[];
 
   constructor() {
@@ -336,7 +336,7 @@ describe('jinframe.test', () => {
   });
 
   it('jin-frame with async pre hook - no return', async () => {
-    nock('http://some.api.google.com').get('/jinframe/pass?name=ironman&skill=beam&skill=flying!').reply(200, {
+    nock('http://some.api.google.com').get('/jinframe/pass?name=ironman&skill[0]=beam&skill[1]=flying!').reply(200, {
       message: 'hello',
     });
 
@@ -347,7 +347,7 @@ describe('jinframe.test', () => {
   });
 
   it('jin-frame with async pre hook - no return', async () => {
-    nock('http://some.api.google.com').get('/jinframe/pass?name=ironman&skill=beam&skill=flying!').reply(200, {
+    nock('http://some.api.google.com').get('/jinframe/pass?name=ironman&skill[]=beam&skill[]=flying!').reply(200, {
       message: 'hello',
     });
 

--- a/src/interfaces/field/IQueryFieldOption.ts
+++ b/src/interfaces/field/IQueryFieldOption.ts
@@ -3,4 +3,16 @@ import type { IQueryParamHeaderCommonFieldOption } from '#interfaces/field/IQuer
 
 export interface IQueryFieldOption extends ICommonFieldOption, IQueryParamHeaderCommonFieldOption {
   type: 'query';
+
+  /**
+   * Querystring Array key formatting
+   *
+   * - brackets
+   *  - a[]=x&a[]=y
+   * - indices
+   *  - a[0]=x&a[1]=y
+   * - one-indices
+   *  - a[1]=x&a[2]=y
+   */
+  keyForamt?: 'brackets' | 'indices' | 'one-indices';
 }

--- a/src/processors/getDefaultOption.test.ts
+++ b/src/processors/getDefaultOption.test.ts
@@ -21,6 +21,7 @@ describe('getDefaultQueryFieldOption', () => {
         enable: false,
         withZero: false,
       },
+      keyFormat: undefined,
       encode: true,
     });
   });

--- a/src/processors/getDefaultOption.ts
+++ b/src/processors/getDefaultOption.ts
@@ -16,6 +16,7 @@ export function getDefaultQueryFieldOption(
       enable: option?.bit?.enable ?? false,
       withZero: option?.bit?.withZero ?? false,
     },
+    keyForamt: option?.keyForamt,
     replaceAt: option?.replaceAt,
     encode: option?.encode ?? true,
   };

--- a/src/processors/getQuerystringKey.test.ts
+++ b/src/processors/getQuerystringKey.test.ts
@@ -1,0 +1,39 @@
+import { getQuerystringKey } from '#processors/getQuerystringKey';
+import { describe, it, expect } from 'vitest';
+
+describe('getQuerystringKey', () => {
+  it('should original key when not format', () => {
+    const result = getQuerystringKey({
+      key: 'ironman',
+      index: 0,
+    });
+    expect(result).toEqual('ironman');
+  });
+
+  it('should original key when brackets format', () => {
+    const result = getQuerystringKey({
+      key: 'ironman',
+      index: 0,
+      format: 'brackets',
+    });
+    expect(result).toEqual('ironman[]');
+  });
+
+  it('should original key when indices format', () => {
+    const result = getQuerystringKey({
+      key: 'ironman',
+      index: 0,
+      format: 'indices',
+    });
+    expect(result).toEqual('ironman[0]');
+  });
+
+  it('should original key when one-indices format', () => {
+    const result = getQuerystringKey({
+      key: 'ironman',
+      index: 0,
+      format: 'one-indices',
+    });
+    expect(result).toEqual('ironman[1]');
+  });
+});

--- a/src/processors/getQuerystringKey.ts
+++ b/src/processors/getQuerystringKey.ts
@@ -1,0 +1,25 @@
+import type { IQueryFieldOption } from '#interfaces/field/IQueryFieldOption';
+
+export function getQuerystringKey({
+  key,
+  index,
+  format,
+}: {
+  key: string;
+  index: number;
+  format?: IQueryFieldOption['keyForamt'];
+}): string {
+  if (format === 'brackets') {
+    return `${key}[]`;
+  }
+
+  if (format === 'indices') {
+    return `${key}[${index}]`;
+  }
+
+  if (format === 'one-indices') {
+    return `${key}[${index + 1}]`;
+  }
+
+  return key;
+}

--- a/src/processors/getQuerystringKeyFormat.test.ts
+++ b/src/processors/getQuerystringKeyFormat.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getQuerystringKeyFormat } from '#processors/getQuerystringKeyFormat';
+
+describe('getQuerystringBrackets', () => {
+  it('should return brackets when pass undefined', () => {
+    const result = getQuerystringKeyFormat();
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return brackets when pass type querystring', () => {
+    const result = getQuerystringKeyFormat({
+      type: 'query',
+      keyForamt: 'brackets',
+      comma: false,
+      bit: {
+        enable: false,
+        withZero: false,
+      },
+    });
+
+    expect(result).toEqual('brackets');
+  });
+
+  it('should return brackets when pass type param', () => {
+    const result = getQuerystringKeyFormat({
+      type: 'param',
+      comma: false,
+      bit: {
+        enable: false,
+        withZero: false,
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/processors/getQuerystringKeyFormat.ts
+++ b/src/processors/getQuerystringKeyFormat.ts
@@ -1,0 +1,17 @@
+import type { IHeaderFieldOption } from '#interfaces/field/IHeaderFieldOption';
+import type { IParamFieldOption } from '#interfaces/field/IParamFieldOption';
+import type { IQueryFieldOption } from '#interfaces/field/IQueryFieldOption';
+
+export function getQuerystringKeyFormat(
+  option?: IQueryFieldOption | IParamFieldOption | IHeaderFieldOption,
+): IQueryFieldOption['keyForamt'] {
+  if (option == null) {
+    return undefined;
+  }
+
+  if (option.type === 'query') {
+    return option.keyForamt;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
- add new option keyFormat
  - keyFormat format querystring key: eg. name[]=ironman&name[]=hulk or name[0]=ironman&name[1]=hulk