### PR TITLE
chore(deps): remove unused dependencies and update package versions

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -77,8 +77,6 @@
     "@apidevtools/json-schema-ref-parser": "^14.2.1",
     "@babel/helper-validator-identifier": "^7.27.1",
     "@jin-frame/generator-core": "workspace:*",
-    "@optique/core": "^0.4.2",
-    "@optique/run": "^0.4.2",
     "axios": "^1.12.1",
     "change-case": "^5.4.4",
     "consola": "^3.4.2",
@@ -91,8 +89,7 @@
     "swagger2openapi": "^7.0.8",
     "type-fest": "^4.41.0",
     "yaml": "^2.8.1",
-    "yargs": "^18.0.0",
-    "zod": "^4.1.8"
+    "yargs": "^18.0.0"
   },
   "peerDependencies": {
     "openapi-typescript": ">=7",

--- a/packages/generator-core/package.json
+++ b/packages/generator-core/package.json
@@ -93,11 +93,8 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^14.2.0",
-    "@optique/core": "^0.4.2",
-    "@optique/run": "^0.4.2",
     "axios": "^1.11.0",
     "change-case": "^5.4.4",
-    "consola": "^3.2.3",
     "my-easy-fp": "^0.22.0",
     "my-node-fp": "^0.10.3",
     "openapi-schema-validator": "^12.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,15 +17,9 @@ importers:
       '@jin-frame/generator-core':
         specifier: workspace:*
         version: link:../generator-core
-      '@optique/core':
-        specifier: ^0.4.2
-        version: 0.4.2
-      '@optique/run':
-        specifier: ^0.4.2
-        version: 0.4.2
       axios:
         specifier: ^1.12.1
-        version: 1.12.1(debug@4.4.1)
+        version: 1.12.1
       change-case:
         specifier: ^5.4.4
         version: 5.4.4
@@ -68,9 +62,6 @@ importers:
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
-      zod:
-        specifier: ^4.1.8
-        version: 4.1.8
     devDependencies:
       '@eslint/compat':
         specifier: ^1.3.2
@@ -174,21 +165,12 @@ importers:
       '@apidevtools/json-schema-ref-parser':
         specifier: ^14.2.0
         version: 14.2.1(@types/json-schema@7.0.15)
-      '@optique/core':
-        specifier: ^0.4.2
-        version: 0.4.2
-      '@optique/run':
-        specifier: ^0.4.2
-        version: 0.4.2
       axios:
         specifier: ^1.11.0
         version: 1.11.0
       change-case:
         specifier: ^5.4.4
         version: 5.4.4
-      consola:
-        specifier: ^3.2.3
-        version: 3.4.2
       my-easy-fp:
         specifier: ^0.22.0
         version: 0.22.0
@@ -1324,14 +1306,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@optique/core@0.4.2':
-    resolution: {integrity: sha512-ZTS+jTsw8fQuHaCZAOeWZuHxn/L/fcxFV6Hzs02fItn4v53MqxdZgvY0Fa/KYDmvE4ZzCm9Lm93bf5tVT32U9Q==}
-    engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
-
-  '@optique/run@0.4.2':
-    resolution: {integrity: sha512-QJUczNryFFnNjTOk8BbkYF53APD4FTrOnKg04M2erKyAsV+rBasXLca6bTT1w1B8DSAlWeSZK62XRedEHWecbA==}
-    engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5113,9 +5087,6 @@ packages:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
 
-  zod@4.1.8:
-    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
-
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -5762,12 +5733,6 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@optique/core@0.4.2': {}
-
-  '@optique/run@0.4.2':
-    dependencies:
-      '@optique/core': 0.4.2
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -6019,7 +5984,7 @@ snapshots:
 
   '@stylistic/eslint-plugin@3.1.0(eslint@9.32.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.43.0(eslint@9.32.0)(typescript@5.9.2)
       eslint: 9.32.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -6031,7 +5996,7 @@ snapshots:
 
   '@stylistic/eslint-plugin@3.1.0(eslint@9.35.0)(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/utils': 8.39.0(eslint@9.35.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.43.0(eslint@9.35.0)(typescript@5.9.2)
       eslint: 9.35.0
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -6309,18 +6274,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.39.0(eslint@9.35.0)(typescript@5.9.2)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.35.0)
-      '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
-      eslint: 9.35.0
-      typescript: 5.9.2
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@typescript-eslint/utils@8.43.0(eslint@9.32.0)(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.32.0)
@@ -6331,7 +6284,6 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@typescript-eslint/utils@8.43.0(eslint@9.35.0)(typescript@5.9.2)':
     dependencies:
@@ -6732,7 +6684,15 @@ snapshots:
 
   axios@1.11.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.12.1:
+    dependencies:
+      follow-redirects: 1.15.11
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -7781,6 +7741,8 @@ snapshots:
   focus-trap@7.6.5:
     dependencies:
       tabbable: 6.2.0
+
+  follow-redirects@1.15.11: {}
 
   follow-redirects@1.15.11(debug@4.4.1):
     optionalDependencies:
@@ -10086,7 +10048,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors-cjs@2.1.3: {}
-
-  zod@4.1.8: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
- Removed `@optique/core` and `@optique/run` from `package.json` in both `generator-cli` and `generator-core`.
- Updated `axios` version in `generator-core` and `generator-cli` to ensure consistency.
- Cleaned up `pnpm-lock.yaml` by removing references to the removed dependencies and ensuring all versions are up to date.