### PR TITLE
feat(frame): add pathPrefix support for API request endpoints

### DIFF
--- a/packages/jin-frame/src/decorators/getFrameOption.ts
+++ b/packages/jin-frame/src/decorators/getFrameOption.ts
@@ -4,6 +4,7 @@ import type { IFrameOption } from '#interfaces/options/IFrameOption';
 export function getFrameOption(method: TMethod, option?: Partial<Omit<IFrameOption, 'method'>>): IFrameOption {
   const frameOption: IFrameOption = {
     host: option?.host,
+    pathPrefix: option?.pathPrefix,
     path: option?.path,
     method,
     customBody: option?.customBody,

--- a/packages/jin-frame/src/frames/AbstractJinFrame.test.ts
+++ b/packages/jin-frame/src/frames/AbstractJinFrame.test.ts
@@ -9,7 +9,9 @@ import { Body } from '#decorators/fields/Body';
 import { Query } from '#decorators/fields/Query';
 
 @Post({
-  host: 'http://some.api.google.com/jinframe/:passing',
+  host: 'http://some.api.google.com',
+  pathPrefix: '/jinframe',
+  path: '/:passing',
   contentType: 'multipart/form-data',
 })
 class Test001PostFrame extends JinFrame<{ message: string }> {

--- a/packages/jin-frame/src/frames/AbstractJinFrame.ts
+++ b/packages/jin-frame/src/frames/AbstractJinFrame.ts
@@ -223,7 +223,9 @@ export abstract class AbstractJinFrame<TPASS> {
 
     // stage 05. url endpoint build
     const { url, isOnlyPath } =
-      option?.url != null ? getUrl(option.url) : getUrl(this.$_option.host, this.$_option.path);
+      option?.url != null
+        ? getUrl(option.url)
+        : getUrl(this.$_option.host, this.$_option.pathPrefix, this.$_option.path);
 
     // stage 06. path parameter evaluation
     const pathfunc = compile(url.pathname);

--- a/packages/jin-frame/src/interfaces/options/IFrameOption.ts
+++ b/packages/jin-frame/src/interfaces/options/IFrameOption.ts
@@ -13,6 +13,27 @@ export interface IFrameOption {
    * */
   host?: string;
 
+  /**
+   * Path prefix of API Request endpoint
+   *
+   * For example, you can set the relative path defined in the OpenAPI Spec's servers field to pathPrefix.
+   * When set, this path will be prepended to the pathname when generating the Request URL.
+   *
+   * @example
+   * ```typescript
+   * // OpenAPI servers configuration:
+   * // servers: [{ "url": "/api/v3" }]
+   * pathPrefix: '/api/v3'
+   * path: '/users/{id}'
+   * // Final URL: https://example.com/api/v3/users/123
+   *
+   * // Multiple path prefixes for different services
+   * pathPrefix: '/user-service/v1'  // User API
+   * pathPrefix: '/order-service/v2' // Order API
+   * ```
+   */
+  pathPrefix?: string;
+
   /** path of API Request endpoint */
   path?: string;
 

--- a/packages/jin-frame/src/tools/slash-utils/getUrl.test.ts
+++ b/packages/jin-frame/src/tools/slash-utils/getUrl.test.ts
@@ -30,6 +30,36 @@ describe('getUrl', () => {
     });
   });
 
+  it('should return concatenated URL when host, pathPrefix and path are all provided', () => {
+    const result = getUrl('http://example.com', '/api', '/:name');
+    expect(result).toEqual({
+      url: new URL('http://example.com/api/:name'),
+      str: 'http://example.com/api/:name',
+      pathname: '/api/:name',
+      isOnlyPath: false,
+    });
+  });
+
+  it('should return concatenated URL when host is undefined and pathPrefix and path are provided', () => {
+    const result = getUrl(undefined, '/api');
+    expect(result).toEqual({
+      url: new URL('http://localhost/api'),
+      str: 'api',
+      pathname: '/api',
+      isOnlyPath: true,
+    });
+  });
+
+  it('should return url when pass path using path argument slot', () => {
+    const result = getUrl(undefined, undefined, '/:name');
+    expect(result).toEqual({
+      url: new URL('http://localhost/:name'),
+      str: ':name',
+      pathname: '/:name',
+      isOnlyPath: true,
+    });
+  });
+
   it('should return url when pass hostname and path without protocol', () => {
     const result = getUrl('example.com/:name');
     expect(result).toEqual({

--- a/packages/jin-frame/src/tools/slash-utils/getUrl.ts
+++ b/packages/jin-frame/src/tools/slash-utils/getUrl.ts
@@ -9,8 +9,19 @@ const pattern2 = /^([A-Za-z0-9-]+\.[A-Za-z]{2,})(\/.*)?$/i;
 // 3) only path (case-sensitive)
 const pattern3 = /^(\/.*)$/;
 
-export function getUrl(host?: string, path?: string): { url: URL; str: string; pathname: string; isOnlyPath: boolean } {
-  const concatted = [host ?? '', path ?? '']
+export function getUrl(
+  host?: string,
+  pathPrefix?: string,
+  path?: string,
+): { url: URL; str: string; pathname: string; isOnlyPath: boolean } {
+  const withPathPrefix =
+    pathPrefix == null && path == null
+      ? undefined
+      : [pathPrefix ?? '', path ?? '']
+          .map((part) => part.trim())
+          .map((part) => removeBothSlash(part))
+          .join('/');
+  const concatted = [host ?? '', withPathPrefix ?? '']
     .map((part) => part.trim())
     .map((part) => removeBothSlash(part))
     .join('/');
@@ -23,13 +34,13 @@ export function getUrl(host?: string, path?: string): { url: URL; str: string; p
   }
 
   // hostname + empty path
-  if (host != null && path == null && pattern2.test(str)) {
+  if (host != null && withPathPrefix == null && pattern2.test(str)) {
     const url = new URL(`http://${str}`);
     return { url, str, pathname: url.pathname, isOnlyPath: false };
   }
 
   // path
-  if (host == null && path != null && pattern3.test(`/${str}`)) {
+  if (host == null && withPathPrefix != null && pattern3.test(`/${str}`)) {
     const url = new URL(`http://localhost/${str}`);
     return { url, str, pathname: url.pathname, isOnlyPath: true };
   }


### PR DESCRIPTION
- Enhanced the IFrameOption interface to include a new optional pathPrefix property for better URL management.
- Updated getFrameOption function to utilize pathPrefix when constructing frame options.
- Modified AbstractJinFrame to accommodate pathPrefix in URL generation logic.
- Adjusted tests to verify correct URL concatenation with host, pathPrefix, and path.