### PR TITLE
feat(retry): implement retry-after header handling and configuration

### DIFF
--- a/packages/jin-frame/src/interfaces/options/IFrameRetry.ts
+++ b/packages/jin-frame/src/interfaces/options/IFrameRetry.ts
@@ -23,4 +23,11 @@ export interface IFrameRetry {
    * Specify a fixed retry interval (in ms). Ignored if getInterval is configured.
    * */
   interval?: number;
+
+  /**
+   * 기본 값은 true, retry-after 헤더를 사용하고 싶을 때 사용, interval, getInterval보다 우선 동작
+   *
+   * Specify to use retry-after header. Prioritized over interval and getInterval.
+   * */
+  useRetryAfter?: boolean;
 }

--- a/packages/jin-frame/src/tools/getRetryAfter.test.ts
+++ b/packages/jin-frame/src/tools/getRetryAfter.test.ts
@@ -1,0 +1,86 @@
+import { getRetryAfter } from '#tools/getRetryAfter';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('getRetryAfter', () => {
+  it('should return retry-after value when useRetryAfter is true and header exists', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    const result = getRetryAfter(retry, '120');
+    expect(result).toEqual(120);
+  });
+
+  it('should return undefined when useRetryAfter is false', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: false };
+
+    const result = getRetryAfter(retry, '120');
+    expect(result).toBeUndefined();
+  });
+
+  it('should handle case-insensitive header names', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    const result = getRetryAfter(retry, '60');
+    expect(result).toEqual(60);
+  });
+
+  it('should handle uppercase header names', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    const result = getRetryAfter(retry, ['30', '60']);
+    expect(result).toEqual(30);
+  });
+
+  it('should return undefined when retry-after value is not a valid number', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    const result = getRetryAfter(retry, 'invalid');
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when retry-after value is empty string', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    const result = getRetryAfter(retry, '');
+    expect(result).toBeUndefined();
+  });
+
+  it('should default useRetryAfter to true when not specified', () => {
+    const retry = { max: 3, try: 1 }; // useRetryAfter not specified
+
+    const result = getRetryAfter(retry, '90');
+    expect(result).toEqual(90);
+  });
+
+  it('should return undefined when header value is undefined', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    const result = getRetryAfter(retry, undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when header value is undefined', () => {
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    const result = getRetryAfter(retry, []);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when parseInt throws error', () => {
+    // Mock the global parseInt function
+    vi.stubGlobal(
+      'parseInt',
+      vi.fn(() => {
+        throw new Error('test');
+      }),
+    );
+
+    const retry = { max: 3, try: 1, useRetryAfter: true };
+
+    // Since the function has try-catch, it should return undefined when parseInt throws
+    const result = getRetryAfter(retry, '30');
+    expect(result).toBeUndefined();
+
+    // Restore the original parseInt
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/jin-frame/src/tools/getRetryAfter.ts
+++ b/packages/jin-frame/src/tools/getRetryAfter.ts
@@ -1,0 +1,27 @@
+import type { IFrameRetry } from '#interfaces/options/IFrameRetry';
+
+export function getRetryAfter(retry: IFrameRetry, rawRetryAfter: string | string[] | undefined): number | undefined {
+  try {
+    const useRetryAfter = retry.useRetryAfter ?? true;
+
+    if (!useRetryAfter || rawRetryAfter == null) {
+      return undefined;
+    }
+
+    const retryAfter = Array.isArray(rawRetryAfter) ? rawRetryAfter.at(0) : rawRetryAfter;
+
+    if (retryAfter == null) {
+      return undefined;
+    }
+
+    const parsed = parseInt(retryAfter, 10);
+
+    if (Number.isNaN(parsed)) {
+      return undefined;
+    }
+
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/jin-frame/src/tools/mergeRetryOption.test.ts
+++ b/packages/jin-frame/src/tools/mergeRetryOption.test.ts
@@ -39,4 +39,13 @@ describe('mergeRetryOption', () => {
 
     expect(merged).toEqual({ max: 2, interval: 1000, getInterval });
   });
+
+  it('should merge useRetryAfter when next provides useRetryAfter', () => {
+    const prev: IFrameRetry = { max: 1, interval: 1000 };
+    const next: IFrameRetry = { max: 2, useRetryAfter: false };
+
+    const merged = mergeRetryOption(prev, next);
+
+    expect(merged).toEqual({ max: 2, interval: 1000, useRetryAfter: false });
+  });
 });

--- a/packages/jin-frame/src/tools/mergeRetryOption.ts
+++ b/packages/jin-frame/src/tools/mergeRetryOption.ts
@@ -5,6 +5,7 @@ export function mergeRetryOption(prev: IFrameRetry, next: IFrameRetry): IFrameRe
     ...prev,
     ...(next.max != null && { max: next.max }),
     ...(next.interval != null && { interval: next.interval }),
+    ...(next.useRetryAfter != null && { useRetryAfter: next.useRetryAfter }),
     ...(next.getInterval != null && { getInterval: next.getInterval }),
   };
 }

--- a/packages/jin-frame/src/tools/responses/getRetryInterval.test.ts
+++ b/packages/jin-frame/src/tools/responses/getRetryInterval.test.ts
@@ -48,4 +48,52 @@ describe('getRetryInterval', () => {
 
     expect(result).toEqual(1000);
   });
+
+  it('should return retry-after value in milliseconds when provided and useRetryAfter is true', () => {
+    const result = getRetryInterval(
+      {
+        max: 10,
+        try: 1,
+        interval: 500,
+        useRetryAfter: true,
+      },
+      1000,
+      1000,
+      120, // 120 seconds
+    );
+
+    expect(result).toEqual(120000); // 120 * 1000 = 120000ms
+  });
+
+  it('should prioritize retry-after over getInterval when useRetryAfter is true', () => {
+    const result = getRetryInterval(
+      {
+        max: 10,
+        try: 2,
+        getInterval: (retry) => retry * 100,
+        useRetryAfter: true,
+      },
+      1000,
+      1000,
+      60,
+    );
+
+    expect(result).toEqual(60000); // Retry-After takes priority
+  });
+
+  it('should use getInterval when retry-after is null and useRetryAfter is true', () => {
+    const result = getRetryInterval(
+      {
+        max: 10,
+        try: 2,
+        getInterval: (retry) => retry * 100,
+        useRetryAfter: true,
+      },
+      1000,
+      1000,
+      undefined,
+    );
+
+    expect(result).toEqual(200); // falls back to getInterval
+  });
 });

--- a/packages/jin-frame/src/tools/responses/getRetryInterval.ts
+++ b/packages/jin-frame/src/tools/responses/getRetryInterval.ts
@@ -4,21 +4,31 @@ import type { IFrameInternal } from '#interfaces/options/IFrameInternal';
  * @param retry retry configuration from the internal data
  * @param totalDuration The total duration(ms) of all retries since the start of the API request
  * @param eachDuration duration(ms) of a single retry attempt
+ * @param retryAfterSeconds Optional Retry-After header value in seconds (takes highest priority)
  */
 export function getRetryInterval(
   retry: NonNullable<IFrameInternal['retry']>,
   totalDuration: number,
   eachDuration: number,
+  retryAfterSeconds?: number,
 ): number {
   const { getInterval, interval } = retry;
 
+  // Priority 1: Retry-After header from server (if useRetryAfter is true)
+  if (retryAfterSeconds != null) {
+    return retryAfterSeconds * 1000; // Convert seconds to milliseconds
+  }
+
+  // Priority 2: Custom getInterval function
   if (getInterval != null) {
     return getInterval(retry.try, totalDuration, eachDuration);
   }
 
+  // Priority 3: Fixed interval
   if (interval != null) {
     return interval;
   }
 
+  // Default fallback
   return 1000;
 }


### PR DESCRIPTION
- Added a new `useRetryAfter` option to the `IFrameRetry` interface to control the usage of the `Retry-After` header.
- Introduced `getRetryAfter` utility function to parse and return the retry-after value in seconds.
- Updated `AbstractJinFrame` to utilize the retry-after value during retry attempts.
- Enhanced `getRetryInterval` to prioritize the retry-after value when configured.
- Added tests for `getRetryAfter` and updated existing tests to cover new functionality.