### PR TITLE
feat(validation): add array key formatting and validator support in d…

### DIFF
--- a/docs/field/query.md
+++ b/docs/field/query.md
@@ -94,6 +94,34 @@ const reply = await BitwiseQueryFrame.of({ flags: [1, 2, 4] }).execute();
 
 > Useful when the API expects bitmask values.
 
+### Array Key Formatting
+
+Use the `@Query({ keyFormat: '...' })` option to specify the **key format** for array queries.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items' })
+export class KeyFormatFrame extends JinFrame {
+  @Query({ keyFormat: 'brackets' })
+  declare readonly tags?: string[];
+  
+  @Query({ keyFormat: 'indices' })
+  declare readonly ids?: number[];
+}
+
+const reply = await KeyFormatFrame.of({ 
+  tags: ['red', 'blue'], 
+  ids: [10, 20] 
+}).execute();
+// → ?tags[]=red&tags[]=blue&ids[0]=10&ids[1]=20
+```
+
+Supported key formats:
+
+- **Default**: `?tags=red&tags=blue` (repeated keys)
+- **`brackets`**: `?tags[]=red&tags[]=blue`
+- **`indices`**: `?tags[0]=red&tags[1]=blue`
+- **`one-indices`**: `?tags[1]=red&tags[2]=blue` (starts from 1)
+
 ## URL Encoding
 
 All keys and values are safely **URL encoded** before being added to the URL.

--- a/docs/ko/field/query.md
+++ b/docs/ko/field/query.md
@@ -94,6 +94,34 @@ const reply = await BitwiseQueryFrame.of({ flags: [1, 2, 4] }).execute();
 
 > API 서버가 비트 마스크 값을 기대할 때 유용합니다.
 
+### 배열 키 포맷 지정
+
+`@Query({ keyFormat: '...' })` 옵션으로 배열 쿼리의 **키 형식**을 지정할 수 있습니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items' })
+export class KeyFormatFrame extends JinFrame {
+  @Query({ keyFormat: 'brackets' })
+  declare readonly tags?: string[];
+  
+  @Query({ keyFormat: 'indices' })
+  declare readonly ids?: number[];
+}
+
+const reply = await KeyFormatFrame.of({ 
+  tags: ['red', 'blue'], 
+  ids: [10, 20] 
+}).execute();
+// → ?tags[]=red&tags[]=blue&ids[0]=10&ids[1]=20
+```
+
+지원하는 키 포맷:
+
+- **기본값**: `?tags=red&tags=blue` (반복 키)
+- **`brackets`**: `?tags[]=red&tags[]=blue`
+- **`indices`**: `?tags[0]=red&tags[1]=blue`
+- **`one-indices`**: `?tags[1]=red&tags[2]=blue` (1부터 시작)
+
 ## URL 인코딩
 
 모든 키와 값은 URL에 추가되기 전에 안전하게 **URL 인코딩**됩니다.

--- a/docs/ko/method/validation.md
+++ b/docs/ko/method/validation.md
@@ -1,0 +1,259 @@
+---
+outline: deep
+---
+
+# Validation
+
+jin-frame의 **Validator**는 HTTP 응답 데이터를 검증하는 기능을 제공하는 클래스입니다. API 응답이 예상한 형태와 일치하는지 확인하고, 잘못된 데이터에 대해 적절한 처리를 할 수 있게 해줍니다.
+
+## 기본 개념
+
+### 검증 타입 (Validation Type)
+
+Validator는 두 가지 검증 타입을 지원합니다:
+
+- **`exception`**: 검증 실패 시 `JinValidationtError` 예외를 발생시킵니다
+- **`value`**: 검증 실패 시 검증 결과를 응답 데이터에 포함시킵니다
+
+### 검증 결과 (Validation Result)
+
+```typescript
+type TValidationResult<TError = unknown> = 
+  | { valid: true }                    // 검증 성공
+  | { valid: false; error: TError[] }  // 검증 실패
+```
+
+## 클래스 구조
+
+```typescript
+export class Validator<TOrigin = unknown, TData = TOrigin, TError = unknown> {
+  constructor({ type }: { type: TValidationResultType })
+  
+  // 응답에서 검증할 데이터를 추출 (오버라이드 가능)
+  getData(reply: TOrigin): TData
+  
+  // 실제 검증 로직 (오버라이드 필수)
+  validator(data: TData): TValidationResult<TError> | Promise<TValidationResult<TError>>
+  
+  // 전체 검증 프로세스 실행
+  validate(reply: TOrigin): Promise<TValidationResult<TError>>
+}
+```
+
+### 제네릭 타입 매개변수
+
+- **`TOrigin`**: 원본 응답 타입 (예: `AxiosResponse<UserData>`)
+- **`TData`**: 검증할 데이터 타입 (예: `UserData`)  
+- **`TError`**: 검증 실패 시 에러 타입 (예: `ZodIssue`)
+
+## 사용 방법
+
+### 기본 사용법
+
+```typescript
+import { Validator } from 'jin-frame';
+import type { AxiosResponse } from 'axios';
+
+class UserValidator extends Validator<
+  AxiosResponse<UserData>,  // 원본 응답 타입
+  UserData,                 // 검증할 데이터 타입
+  ValidationError           // 에러 타입
+> {
+  constructor() {
+    super({ type: 'exception' }); // 예외 발생 모드
+  }
+
+  // 응답에서 검증할 데이터 추출
+  override getData(reply: AxiosResponse<UserData>): UserData {
+    return reply.data;
+  }
+
+  // 실제 검증 로직 구현
+  override validator(data: UserData): TValidationResult<ValidationError> {
+    // Zod, Joi, 또는 커스텀 검증 로직
+    const result = userSchema.safeParse(data);
+    
+    if (result.success) {
+      return { valid: true };
+    }
+    
+    return { 
+      valid: false, 
+      error: result.error.issues 
+    };
+  }
+}
+```
+
+### JinFrame과 함께 사용
+
+```typescript
+@Post({
+  host: 'https://api.example.com',
+  path: '/users',
+  validator: new UserValidator(), // 검증기 등록
+})
+class CreateUserFrame extends JinFrame<UserData> {
+  @Body()
+  declare name: string;
+
+  @Body() 
+  declare email: string;
+}
+```
+
+### Zod를 활용한 검증
+
+```typescript
+import { z } from 'zod';
+
+const messageSchema = z.object({
+  message: z.string(),
+  timestamp: z.number(),
+});
+
+class MessageValidator extends Validator<
+  AxiosResponse<{ message: string; timestamp: number }>,
+  { message: string; timestamp: number },
+  z.ZodIssue
+> {
+  constructor() {
+    super({ type: 'exception' });
+  }
+
+  override getData(reply: AxiosResponse<{ message: string; timestamp: number }>) {
+    return reply.data;
+  }
+
+  override validator(data: { message: string; timestamp: number }) {
+    const result = messageSchema.safeParse(data);
+    
+    if (result.success) {
+      return { valid: true };
+    }
+    
+    return { 
+      valid: false, 
+      error: result.error.issues 
+    };
+  }
+}
+```
+
+## 검증 모드
+
+### Exception 모드
+
+```typescript
+const validator = new UserValidator({ type: 'exception' });
+```
+
+- 검증 실패 시 `JinValidationtError` 예외 발생
+- 애플리케이션 로직에서 try-catch로 처리
+- **권장**: 대부분의 경우에 사용
+
+### Value 모드  
+
+```typescript
+const validator = new UserValidator({ type: 'value' });
+```
+
+- 검증 실패 시 응답 객체에 검증 결과 포함
+- 응답 객체의 `$validated` 속성에서 결과 확인
+- **용도**: 검증 결과를 클라이언트에 전달해야 하는 경우
+
+## 실제 사용 예제
+
+```typescript
+// 1. 검증기 정의
+class ProductValidator extends Validator<
+  AxiosResponse<Product>,
+  Product,
+  ValidationError
+> {
+  constructor() {
+    super({ type: 'exception' });
+  }
+
+  override getData(reply: AxiosResponse<Product>): Product {
+    return reply.data;
+  }
+
+  override validator(product: Product): TValidationResult<ValidationError> {
+    if (!product.id || product.price < 0) {
+      return {
+        valid: false,
+        error: [{ message: 'Invalid product data' }]
+      };
+    }
+    
+    return { valid: true };
+  }
+}
+
+// 2. Frame에 적용
+@Get({
+  host: 'https://api.shop.com',
+  path: '/products/:id',
+  validator: new ProductValidator(),
+})
+class GetProductFrame extends JinFrame<Product> {
+  @Param()
+  declare id: string;
+}
+
+// 3. 사용
+try {
+  const frame = GetProductFrame.of({ id: '123' });
+  const response = await frame.execute();
+  // 검증이 성공한 경우에만 여기 도달
+  console.log('Valid product:', response.data);
+} catch (error) {
+  if (error instanceof JinValidationtError) {
+    console.log('Validation failed:', error.validated);
+  }
+}
+```
+
+## 장점
+
+### 타입 안전성
+
+- TypeScript 제네릭으로 완전한 타입 추론
+- 컴파일 타임에 타입 오류 감지
+
+### 유연한 검증 로직  
+
+- 어떤 검증 라이브러리든 사용 가능 (Zod, Joi, Yup 등)
+- 커스텀 검증 로직 구현 가능
+
+### 일관된 에러 처리
+
+- 표준화된 검증 결과 형태
+- 예외/값 반환 모드 선택 가능
+
+### 프레임워크 통합
+
+- JinFrame과 완벽 통합
+- 데코레이터 패턴으로 간편한 설정
+
+## 에러 처리
+
+검증 실패 시 발생하는 `JinValidationtError`는 다음 정보를 포함합니다:
+
+```typescript
+interface JinValidationtError {
+  message: string;                    // 에러 메시지
+  validated: TValidationResult;       // 검증 결과
+  validator: Validator;               // 사용된 검증기
+  debug: IDebugInfo;                  // 디버그 정보
+  frame: JinFrame;                    // 프레임 인스턴스
+  resp: AxiosResponse;                // 응답 객체
+}
+```
+
+이를 통해 검증 실패 원인을 상세히 분석할 수 있습니다.
+
+---
+
+Validator는 API 응답의 **데이터 무결성을 보장**하고 **예상치 못한 데이터로 인한 런타임 오류를 방지**하는 핵심 기능입니다. 특히 외부 API를 사용할 때 응답 형태가 변경되거나 예상과 다른 데이터가 올 경우를 대비할 수 있습니다.

--- a/docs/ko/usage-method.md
+++ b/docs/ko/usage-method.md
@@ -19,13 +19,13 @@ outline: deep
 @Get({
   host: 'https://api.example.com',
   path: '/orgs/:orgId/users',
-  authorization: process.env.YOUR_AUTH_TOKEN
+  authorization: process.env.YOUR_AUTH_TOKEN,
 })
 export class ListUsersFrame extends JinFrame {
-  @Param() 
+  @Param()
   declare readonly orgId: string;
 
-  @Query() 
+  @Query()
   declare readonly page?: number;
 }
 
@@ -62,10 +62,10 @@ const res = await frame.execute();
   contentType: 'multipart/form-data',
 })
 export class UploadFrame extends JinFrame {
-  @Body() 
+  @Body()
   declare readonly title: string;
-  
-  @Body() 
+
+  @Body()
   declare readonly attachments: JinFile[]; // JinFile 또는 JinFile[] 지원
 }
 
@@ -78,15 +78,15 @@ await frame.execute();
 ### PUT / PATCH / DELETE
 
 ```ts
-@Patch({ 
-  host: 'https://api.example.com', 
+@Patch({
+  host: 'https://api.example.com',
   path: '/users/:id',
 })
 export class UpdateUserFrame extends JinFrame {
-  @Param() 
+  @Param()
   declare readonly id: string;
-  
-  @Body() 
+
+  @Body()
   declare readonly name?: string;
 }
 
@@ -95,7 +95,7 @@ export class UpdateUserFrame extends JinFrame {
   path: '/users/:id',
 })
 export class DeleteUserFrame extends JinFrame {
-  @Param() 
+  @Param()
   declare readonly id: string;
 }
 ```
@@ -108,6 +108,7 @@ export class DeleteUserFrame extends JinFrame {
 | ------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | `host`             | `string`                                                                             | 베이스 URL(프로토콜 포함). 예: `https://api.example.com`                        |
 | `path`             | `string`                                                                             | 경로. `:id` 처럼 **Path Param** 플레이스홀더 지원                               |
+| `pathPrefix`       | `string`                                                                             | `/api` 와 같이 path에 추가할 prefix를 설정할 수 있습니다.                       |
 | `timeout`          | `number`                                                                             | 요청 타임아웃(ms). 미설정 시 라이브러리 기본값 사용                             |
 | `retry`            | `{ max: number; interval?: number }` \*                                              | 재시도 설정. `max`는 최대 시도 횟수, `interval`은 시도 간 대기(ms)              |
 | `method`           | `string`                                                                             | 내부적으로 설정되지만, 커스텀 메서드가 필요하면 명시 가능                       |
@@ -117,6 +118,7 @@ export class DeleteUserFrame extends JinFrame {
 | `validateStatus`   | `(status: number) => boolean`                                                        | axios 상태 검증기. 재시도 조건과 함께 사용 가능                                 |
 | `userAgent`        | `string`                                                                             | User-Agent 지정. 브라우저 보안 제약으로 무시될 수 있음(옵션으로는 설정 가능)    |
 | `authorization`    | `string` or `{ usename: string; password: string }`                                  | Header Authorization 필드 값을 설정하거나 Basic Auth 설정을 설정                |
+| `validator`        | `Validator`                                                                          | `Validator` 클래스를 상속하여 Validator를 전달합니다                            |
 
 ## Body 전송 규칙 & Content-Type
 

--- a/docs/method/validation.md
+++ b/docs/method/validation.md
@@ -1,0 +1,259 @@
+---
+outline: deep
+---
+
+# Validation
+
+The **Validator** in jin-frame is a class that provides functionality for validating HTTP response data. It ensures that API responses match the expected format and enables appropriate handling of invalid data.
+
+## Basic Concepts
+
+### Validation Types
+
+Validator supports two validation types:
+
+- **`exception`**: Throws a `JinValidationtError` exception when validation fails
+- **`value`**: Includes validation results in the response data when validation fails
+
+### Validation Result
+
+```typescript
+type TValidationResult<TError = unknown> = 
+  | { valid: true }                    // Validation success
+  | { valid: false; error: TError[] }  // Validation failure
+```
+
+## Class Structure
+
+```typescript
+export class Validator<TOrigin = unknown, TData = TOrigin, TError = unknown> {
+  constructor({ type }: { type: TValidationResultType })
+  
+  // Extract data to validate from response (overridable)
+  getData(reply: TOrigin): TData
+  
+  // Actual validation logic (must override)
+  validator(data: TData): TValidationResult<TError> | Promise<TValidationResult<TError>>
+  
+  // Execute the entire validation process
+  validate(reply: TOrigin): Promise<TValidationResult<TError>>
+}
+```
+
+### Generic Type Parameters
+
+- **`TOrigin`**: Original response type (e.g., `AxiosResponse<UserData>`)
+- **`TData`**: Data type to validate (e.g., `UserData`)  
+- **`TError`**: Error type for validation failures (e.g., `ZodIssue`)
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { Validator } from 'jin-frame';
+import type { AxiosResponse } from 'axios';
+
+class UserValidator extends Validator<
+  AxiosResponse<UserData>,  // Original response type
+  UserData,                 // Data type to validate
+  ValidationError           // Error type
+> {
+  constructor() {
+    super({ type: 'exception' }); // Exception mode
+  }
+
+  // Extract data to validate from response
+  override getData(reply: AxiosResponse<UserData>): UserData {
+    return reply.data;
+  }
+
+  // Implement actual validation logic
+  override validator(data: UserData): TValidationResult<ValidationError> {
+    // Zod, Joi, or custom validation logic
+    const result = userSchema.safeParse(data);
+    
+    if (result.success) {
+      return { valid: true };
+    }
+    
+    return { 
+      valid: false, 
+      error: result.error.issues 
+    };
+  }
+}
+```
+
+### Usage with JinFrame
+
+```typescript
+@Post({
+  host: 'https://api.example.com',
+  path: '/users',
+  validator: new UserValidator(), // Register validator
+})
+class CreateUserFrame extends JinFrame<UserData> {
+  @Body()
+  declare name: string;
+
+  @Body() 
+  declare email: string;
+}
+```
+
+### Validation with Zod
+
+```typescript
+import { z } from 'zod';
+
+const messageSchema = z.object({
+  message: z.string(),
+  timestamp: z.number(),
+});
+
+class MessageValidator extends Validator<
+  AxiosResponse<{ message: string; timestamp: number }>,
+  { message: string; timestamp: number },
+  z.ZodIssue
+> {
+  constructor() {
+    super({ type: 'exception' });
+  }
+
+  override getData(reply: AxiosResponse<{ message: string; timestamp: number }>) {
+    return reply.data;
+  }
+
+  override validator(data: { message: string; timestamp: number }) {
+    const result = messageSchema.safeParse(data);
+    
+    if (result.success) {
+      return { valid: true };
+    }
+    
+    return { 
+      valid: false, 
+      error: result.error.issues 
+    };
+  }
+}
+```
+
+## Validation Modes
+
+### Exception Mode
+
+```typescript
+const validator = new UserValidator({ type: 'exception' });
+```
+
+- Throws `JinValidationtError` exception on validation failure
+- Handle with try-catch in application logic
+- **Recommended**: Use for most cases
+
+### Value Mode  
+
+```typescript
+const validator = new UserValidator({ type: 'value' });
+```
+
+- Includes validation results in response object on validation failure
+- Check results in the `$validated` property of response object
+- **Use case**: When validation results need to be passed to client
+
+## Real-world Example
+
+```typescript
+// 1. Define validator
+class ProductValidator extends Validator<
+  AxiosResponse<Product>,
+  Product,
+  ValidationError
+> {
+  constructor() {
+    super({ type: 'exception' });
+  }
+
+  override getData(reply: AxiosResponse<Product>): Product {
+    return reply.data;
+  }
+
+  override validator(product: Product): TValidationResult<ValidationError> {
+    if (!product.id || product.price < 0) {
+      return {
+        valid: false,
+        error: [{ message: 'Invalid product data' }]
+      };
+    }
+    
+    return { valid: true };
+  }
+}
+
+// 2. Apply to Frame
+@Get({
+  host: 'https://api.shop.com',
+  path: '/products/:id',
+  validator: new ProductValidator(),
+})
+class GetProductFrame extends JinFrame<Product> {
+  @Param()
+  declare id: string;
+}
+
+// 3. Usage
+try {
+  const frame = GetProductFrame.of({ id: '123' });
+  const response = await frame.execute();
+  // Reaches here only if validation succeeds
+  console.log('Valid product:', response.data);
+} catch (error) {
+  if (error instanceof JinValidationtError) {
+    console.log('Validation failed:', error.validated);
+  }
+}
+```
+
+## Advantages
+
+### Type Safety
+
+- Complete type inference with TypeScript generics
+- Compile-time type error detection
+
+### Flexible Validation Logic  
+
+- Use any validation library (Zod, Joi, Yup, etc.)
+- Implement custom validation logic
+
+### Consistent Error Handling
+
+- Standardized validation result format
+- Choose between exception/value return modes
+
+### Framework Integration
+
+- Perfect integration with JinFrame
+- Simple configuration with decorator pattern
+
+## Error Handling
+
+The `JinValidationtError` thrown on validation failure includes the following information:
+
+```typescript
+interface JinValidationtError {
+  message: string;                    // Error message
+  validated: TValidationResult;       // Validation result
+  validator: Validator;               // Used validator
+  debug: IDebugInfo;                  // Debug information
+  frame: JinFrame;                    // Frame instance
+  resp: AxiosResponse;                // Response object
+}
+```
+
+This allows detailed analysis of validation failure causes.
+
+---
+
+Validator is a core feature that **ensures data integrity of API responses** and **prevents runtime errors caused by unexpected data**. It's especially useful when using external APIs where response formats might change or unexpected data might be received.

--- a/docs/usage-method.md
+++ b/docs/usage-method.md
@@ -111,6 +111,7 @@ All method decorators (`@Get`, `@Post`, …) accept common options:
 | ------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
 | `host`             | `string`                                                                             | Base URL (including protocol). Example: `https://api.example.com`           |
 | `path`             | `string`                                                                             | Path. Supports **Path Param** placeholders like `:id`                       |
+| `pathPrefix`       | `string`                                                                             | Path prefix to prepend to the path, such as `/api`                         |
 | `timeout`          | `number`                                                                             | Request timeout (ms). Uses library default if not set                       |
 | `retry`            | `{ max: number; interval?: number }` \*                                              | Retry policy. `max` is max attempts, `interval` is delay between retries(ms)|
 | `method`           | `string`                                                                             | Normally set internally, but can be overridden for custom methods           |
@@ -120,6 +121,7 @@ All method decorators (`@Get`, `@Post`, …) accept common options:
 | `validateStatus`   | `(status: number) => boolean`                                                        | Axios status validator. Works with retry conditions                         |
 | `userAgent`        | `string`                                                                             | Sets User-Agent. May be ignored due to browser security restrictions        |
 | `authorization`    | `string` or `{ username: string; password: string }`                                 | Configure `Authorization` header directly or with Basic Auth                |
+| `validator`        | `Validator`                                                                          | Pass a custom `Validator` instance by extending the `Validator` class       |
 
 ## Body Transmission Rules & Content-Type
 


### PR DESCRIPTION
…ocumentation

- Introduced documentation for array key formatting options in query parameters, detailing supported formats.
- Added `pathPrefix` and `validator` options to method decorators in usage documentation.
- Created comprehensive validation documentation, explaining the Validator class and its usage with JinFrame.
- Included examples for implementing custom validators and handling validation results.