### PR TITLE
fix(docs-deploy): update TypeDoc and VitePress build commands for jin…

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -50,12 +50,12 @@ jobs:
         run: pnpm install
       - name: Build TypeDoc
         run: |
-          pnpm run docs:typedoc
+          pnpm --filter jin-frame run docs:typedoc
           cp -r ./assets ./docs/assets
           mkdir ./docs/public
           cp -r ./assets ./docs/public/assets
       - name: Build with VitePress
-        run: pnpm run docs:build:prod
+        run: pnpm --filter jin-frame run docs:build:prod
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/packages/jin-frame/.configs/typedoc.json
+++ b/packages/jin-frame/.configs/typedoc.json
@@ -5,7 +5,7 @@
   "tsconfig": "../tsconfig.json",
   "entryPointStrategy": "expand",
   "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
-  "out": "../docs/api",
+  "out": "../../docs/api",
   "excludePrivate": true,
   "excludeInternal": true,
   "readme": "none",


### PR DESCRIPTION
…-frame

- Modified the build commands in the GitHub Actions workflow to use the `--filter jin-frame` option for both TypeDoc and VitePress, ensuring the correct package is built.
- Adjusted the output path in the TypeDoc configuration to reflect the new directory structure, changing it from `../docs/api` to `../../docs/api`.