### PR TITLE
fix(docs-deploy): update output path for VitePress build in workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -55,7 +55,9 @@ jobs:
           mkdir ./docs/public
           cp -r ./assets ./docs/public/assets
       - name: Build with VitePress
-        run: pnpm --filter jin-frame run docs:build:prod
+        run: |
+          pnpm --filter jin-frame run docs:build:prod
+          mv ./packages/jin-frame/docs/.vitepress/dist ./docs/.vitepress
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
- Added a step to move the VitePress build output to the correct directory within the documentation structure, ensuring proper deployment of generated files.