### PR TITLE
fix(docs): correct output path in TypeDoc configuration for jin-frame documentation

### DIFF
--- a/packages/jin-frame/.configs/typedoc.json
+++ b/packages/jin-frame/.configs/typedoc.json
@@ -5,7 +5,7 @@
   "tsconfig": "../tsconfig.json",
   "entryPointStrategy": "expand",
   "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
-  "out": "../../docs/api",
+  "out": "../docs/api",
   "excludePrivate": true,
   "excludeInternal": true,
   "readme": "none",


### PR DESCRIPTION
- Updated the output path in the TypeDoc configuration from `../../docs/api` to `../docs/api` to align with the new directory structure.