### PR TITLE
feat(docs): add comprehensive documentation for jin-frame features

### DIFF
--- a/packages/jin-frame/docs/field/body.md
+++ b/packages/jin-frame/docs/field/body.md
@@ -1,0 +1,161 @@
+---
+outline: deep
+---
+
+# Body
+
+In **`jin-frame`**, when you declare a class field with the `@Body()` decorator, the field value is **serialized into the HTTP Request Body** and included in the request. It is mainly used for `POST`, `PUT`, and `PATCH` requests, with JSON serialization supported by default.
+
+## Quick Example
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class CreateUserFrame extends JinFrame {
+  @Body() declare readonly username: string;
+  @Body() declare readonly age?: number;
+  @Body() declare readonly tags?: string[];
+  @Body() declare readonly isAdmin?: boolean;
+}
+
+// Execute
+const frame = CreateUserFrame.of({ username: 'pikachu', age: 7, tags: ['red', 'blue'], isAdmin: false });
+const reply = await frame.execute();
+
+console.log(reply.config.data);
+// { "username": "pikachu", "age": 7, "tags": ["red","blue"], "isAdmin": false }
+```
+
+## Structure Definition
+
+`@Body()` defines the body object **at the field level**. For example, consider the following type:
+
+```ts
+interface IamBody {
+  name: string;
+  age: number;
+}
+```
+
+When using `@Body()`, you define fields separately as follows:
+
+```ts
+@Post({ host: 'https://api.someapi.com', path: '/api/some/path' })
+class PostFrameExample extends JinFrame {
+  @Body()
+  declare public readonly name: string;
+
+  @Body()
+  declare public readonly age: number;
+}
+```
+
+Here, the properties of `IamBody` (`name`, `age`) are declared individually with `@Body`. If you want to handle the entire object as a single field, you should use **`@ObjectBody`** instead.
+
+## Body vs ObjectBody
+
+| Aspect        | `@Body`                                  | `@ObjectBody`                                |
+| ------------- | ---------------------------------------- | -------------------------------------------- |
+| Declaration   | Define each field separately             | Define the whole object as a single field    |
+| Example       | `@Body() declare readonly name: string;` | `@ObjectBody() declare readonly user: User;` |
+| Serialization | Multiple fields merged into the Body     | Serializes the declared object as-is         |
+| Use Cases     | Simple field-based API requests          | Pass DTOs or interfaces as the body directly |
+
+## Supported Types & Serialization
+
+Types supported by `@Body()` and their JSON-serialized forms:
+
+| Type                 | Example value      | Serialized form               |
+| -------------------- | ------------------ | ----------------------------- |
+| `string`             | `'pikachu'`        | `"pikachu"`                   |
+| `number`             | `2`                | `2`                           |
+| `boolean`            | `true`             | `true`                        |
+| `string[]`           | `['a','b']`        | `["a","b"]`                   |
+| `number[]`           | `[1,2,4]`          | `[1,2,4]`                     |
+| `object`             | `{ key: "value" }` | `{ "key": "value" }`          |
+| `undefined` / `null` | `undefined`/`null` | **omitted** (key not created) |
+
+- `undefined` / `null` values are omitted by default.
+- Arrays and objects are serialized directly as JSON.
+
+## Nested Objects
+
+Nested objects are also supported.
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class NestedBodyFrame extends JinFrame {
+  @Body() declare readonly profile: { name: string; age: number };
+  @Body() declare readonly settings?: { theme: string; notifications: boolean };
+}
+
+const reply = await NestedBodyFrame.of({
+  profile: { name: 'pikachu', age: 7 },
+  settings: { theme: 'dark', notifications: true },
+}).execute();
+
+// Body → { "profile": { "name": "pikachu", "age": 7 }, "settings": { "theme": "dark", "notifications": true } }
+```
+
+## Array Options
+
+Arrays are serialized as JSON arrays. Unlike query strings, there is no need for `comma` or `bitwise` options.
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/batch' })
+export class ArrayBodyFrame extends JinFrame {
+  @Body() declare readonly ids: number[];
+}
+
+const reply = await ArrayBodyFrame.of({ ids: [1, 2, 3] }).execute();
+// Body → { "ids": [1,2,3] }
+```
+
+## Optional Fields
+
+If no value is provided, the key is **omitted from the body**.
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class OptionalBodyFrame extends JinFrame {
+  @Body() declare readonly username: string;
+  @Body() declare readonly nickname?: string;
+}
+
+const reply = await OptionalBodyFrame.of({ username: 'pikachu' }).execute();
+// Body → { "username": "pikachu" }
+```
+
+## Combining with Params & Headers
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class CreateUserInOrgFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Header() declare readonly Authorization: string;
+  @Body() declare readonly username: string;
+  @Body() declare readonly age: number;
+}
+
+const reply = await CreateUserInOrgFrame.of({
+  orgId: 'acme',
+  Authorization: 'Bearer token',
+  username: 'pikachu',
+  age: 7,
+}).execute();
+
+// POST /orgs/acme/users
+// Headers: { Authorization: "Bearer token" }
+// Body: { "username": "pikachu", "age": 7 }
+```
+
+## Debugging Tip
+
+Before sending a request, you can check the **final body data** using `frame.getData('body')`.
+
+```ts
+const frame = CreateUserFrame.of({ username: 'pikachu', age: 7 });
+const req = frame.request();
+
+console.log(frame.getData('body')); // { username: 'pikachu', age: 7 }
+console.log(req.data); // Final serialized body
+```

--- a/packages/jin-frame/docs/field/formatters.md
+++ b/packages/jin-frame/docs/field/formatters.md
@@ -1,0 +1,220 @@
+# Formatters
+
+The decorators `@Query()`, `@Param()`, `@Body()`, `@ObjectBody()`, and `@Header()` provide the **formatters** option to process values before they are serialized.
+
+Processing steps differ slightly depending on the decorator:
+
+- For `@Query()`, `@Param()`, and `@Header()`:  
+  **Collect value → apply formatter (sequential chain) → apply array options (comma/bit) → URL encoding**
+- For `@Body()` and `@ObjectBody()`:  
+  **Collect value → apply formatter (sequential chain)**
+
+> Rules
+>
+> - Returning `undefined` or `null` will cause the key to be **omitted**.
+> - For **array fields**, formatters are applied **individually to each element**.
+> - `formatters` can be a single object or an **array of objects** applied sequentially.
+> - Return values can be primitives (`string`, `number`, `boolean`) or arrays.
+> - Example: transformations like **string → Date → epoch time** can be chained together.
+
+## Formatter Options
+
+| Field         | Type                                          | Description                                                                                                                                    |
+| ------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `order`       | `('string' \| 'number' \| 'dateTime')[]`      | Specifies the order in which formatters are applied. Default is `['number', 'string', 'dateTime']`.                                            |
+| `ignoreError` | `boolean`                                     | Determines whether to discard the value on error. If `true`, errors are ignored and the value is excluded; if `false`, an exception is thrown. |
+| `number`      | `(value: number) => number \| Date \| string` | Formatter for numeric values. May return `number`, `Date`, or `string`.                                                                        |
+| `string`      | `(value: string) => string \| Date`           | Formatter for string values. May return `string` or `Date`.                                                                                    |
+| `dateTime`    | `(value: Date) => string`                     | Formatter for `Date` values. Must return a `string`.                                                                                           |
+
+## Notes
+
+Formatters operate only if the input type matches (`string`, `number`, or `Date`). If the input type does not match, the transformation may be skipped or the value may be omitted.
+
+- If a transformation does not work as expected, first check that the **input type is correct**.
+- If necessary, use the `ignoreError` option to suppress errors and safely exclude invalid values.
+
+## Single Value Formatting
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class FormatterSingleFrame extends JinFrame {
+  @Query({
+    formatters: { string: (v: string) => v.trim().toLowerCase() }, // string → lowercase
+  })
+  declare readonly q?: string;
+
+  @Query({
+    formatters: { number: (v: number) => Number(v.toFixed(2)) }, // number → round to 2 decimals
+  })
+  declare readonly price?: number;
+
+  @Query({
+    formatters: {
+      dateTime: (d: Date) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`,
+    },
+    // Date → yyyy-MM-dd
+  })
+  declare readonly date?: Date;
+}
+
+const reply = await FormatterSingleFrame.of({
+  q: '  Pikachu ',
+  price: 12.345,
+  date: new Date('2025-08-21'),
+}).execute();
+// → ?q=pikachu&price=12.35&date=2025-08-21
+```
+
+## Array Element Formatting (per element)
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class FormatterArrayFrame extends JinFrame {
+  @Query({
+    formatters: { string: (tag: string) => tag.trim().toLowerCase() }, // applied to each array element
+  })
+  declare readonly tags?: string[];
+}
+
+const reply = await FormatterArrayFrame.of({ tags: ['  RED ', '  Blue'] }).execute();
+// → ?tags=red&tags=blue
+```
+
+## Multiple Formatters (chained)
+
+### Pass an array of formatters
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/convert' })
+export class FormatterChainFrame extends JinFrame {
+  @Query({
+    formatters: [
+      { string: (s: string) => s.trim() }, // string → trimmed string
+      { string: (s: string) => new Date(s) }, // string → Date
+      { dateTime: (d: Date) => `${Math.floor(d.getTime())}` }, // Date → epoch(ms)
+    ],
+  })
+  declare readonly dates?: string[];
+}
+
+const reply = await FormatterChainFrame.of({ dates: ['2025-08-01', '2025-08-02'] }).execute();
+// → ?dates=1754006400000&dates=1754092800000
+```
+
+### Use the `order` option
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/convert' })
+export class FormatterChainFrame extends JinFrame {
+  @Query({
+    formatters: [
+      {
+        order: ['number', 'string', 'dateTime'], // number → string → dateTime
+        string: (s: string) => new Date(s.trim()), // string → Date
+        dateTime: (d: Date) => `${Math.floor(d.getTime())}`, // Date → epoch(ms)
+      },
+    ],
+  })
+  declare readonly dates?: string[];
+}
+```
+
+## Arrays + Comma Serialization with Formatters
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class FormatterCommaFrame extends JinFrame {
+  @Query({
+    comma: true, // serialize array with commas
+    formatters: { string: (tag: string) => `c-${tag.trim()}` }, // add prefix to each element
+  })
+  declare readonly tags?: string[];
+}
+
+const reply = await FormatterCommaFrame.of({ tags: ['red', ' blue ', 'green,'] }).execute();
+// → ?tags=c-red,c-blue,c-green
+```
+
+## Numeric Arrays + Bitwise OR with Normalization
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags' })
+export class FormatterBitFrame extends JinFrame {
+  @Query({
+    bit: { enable: true }, // enable bitwise OR
+    formatters: { number: (f?: number) => (Number.isFinite(f) && f! >= 0 ? Number(f) : undefined) },
+    // exclude negative or NaN values
+  })
+  declare readonly flags?: number[];
+}
+
+const reply = await FormatterBitFrame.of({ flags: [1, 2, 4] }).execute();
+// → ?flags=7
+```
+
+## Enum / Mapping Conversion
+
+```ts
+const TAG_MAP: Record<string, string> = { red: 'R', blue: 'B', green: 'G' };
+
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class FormatterMapFrame extends JinFrame {
+  @Query({
+    formatters: { string: (tag?: string) => (tag ? TAG_MAP[tag] : undefined) }, // mapping conversion
+  })
+  declare readonly tags?: string[];
+}
+
+const reply = await FormatterMapFrame.of({ tags: ['red', 'blue', 'green'] }).execute();
+// → ?tags=R&tags=B&tags=G
+```
+
+## Formatter in @Body and @ObjectBody
+
+`@Body()` and `@ObjectBody()` work with objects, so you must explicitly specify which field the formatter should apply to.  
+Use the `findFrom` option to **designate the path**.
+
+```ts
+@Post({ host: 'http://some.api.google.com/jinframe/:passing' })
+class ObjectFormatterExample extends JinFrame {
+  @Param()
+  declare public readonly passing: string;
+
+  @ObjectBody({
+    formatters: [
+      {
+        findFrom: 'name', // apply formatter to the "name" field
+        string(value) {
+          return `${value}::111`;
+        },
+      },
+      {
+        findFrom: 'date', // apply formatter to the "date" field
+        dateTime(value) {
+          const f = lightFormat(value, 'yyyy-MM-dd');
+          return f;
+        },
+      },
+    ],
+  })
+  declare public readonly ability: {
+    name: string;
+    date: Date;
+    desc: string;
+  };
+}
+```
+
+## Summary
+
+Formatters can be used for various purposes, such as:
+
+- String normalization
+- Date transformation
+- Array serialization optimization
+- Bitmask handling
+- Enum/mapping conversion
+
+Especially in `@Body` and `@ObjectBody`, you can apply fine-grained control at the DTO object level, making it possible to manage even complex API requests declaratively and cleanly.

--- a/packages/jin-frame/docs/field/header.md
+++ b/packages/jin-frame/docs/field/header.md
@@ -1,0 +1,168 @@
+---
+outline: deep
+---
+
+# Header
+
+When you declare a class field with the `@Header()` decorator in `jin-frame`, the field value is **serialized into an HTTP header** and included in the request.
+
+## Quick Example
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class SearchFrame extends JinFrame {
+  @Header() declare readonly Authorization: string;
+  @Header() declare readonly 'X-Tracking-Id'?: string;
+  @Header() declare readonly 'X-Tags'?: string[]; // → X-Tags: red (repeat)  X-Tags: blue
+  @Header() declare readonly 'X-Debug'?: boolean; // → X-Debug: true
+}
+
+// Execute
+const frame = SearchFrame.of({
+  Authorization: 'Bearer token',
+  'X-Tracking-Id': '1234',
+  'X-Tags': ['red', 'blue'],
+  'X-Debug': true,
+});
+const reply = await frame.execute();
+
+// Sent headers:
+// Authorization: Bearer token
+// X-Tracking-Id: 1234
+// X-Tags: red
+// X-Tags: blue
+// X-Debug: true
+```
+
+## Supported Types & Serialization
+
+`@Header()` supports the following types and serializes them as shown:
+
+<!-- markdownlint-disable MD033 -->
+
+| Type                 | Option  | Example value      | Serialized form (header line)               |
+| -------------------- | ------- | ------------------ | ------------------------------------------- |
+| `string`             |         | `'token'`          | `X-Auth: token`                             |
+| `number`             |         | `2`                | `X-Page: 2`                                 |
+| `boolean`            |         | `true`             | `X-Debug: true`                             |
+| `string[]`           | comma ✗ | `['a','b']`        | `X-Tags: "[\"a\", \"b\"]"`                  |
+| `string[]`           | comma ✓ | `['a','b']`        | `X-Tags: a,b`                               |
+| `number[]`           | bit ✗   | `[1,2,4]`          | `X-Flags: "[\"1\", \"2\", \"4\"]"`          |
+| `number[]`           | bit ✓   | `[1,2,4]`          | `X-Flags: 7`<br />(bitwise OR: 1\|2\|4 = 7) |
+| `undefined` / `null` |         | `undefined`/`null` | **omitted** (header not created)            |
+
+<!-- markdownlint-enable MD033 -->
+
+- The default array serialization is **repeated headers**.
+- Numbers and booleans are converted to strings.
+- `undefined` / `null` values are automatically omitted.
+
+## Array Options
+
+### Default Array Serialization (Repeated Headers)
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class ArrayHeaderFrame extends JinFrame {
+  @Header() declare readonly 'X-Tags'?: string[];
+}
+
+await ArrayHeaderFrame.of({ 'X-Tags': ['red', 'blue'] }).execute();
+// → X-Tags: red
+// → X-Tags: blue
+```
+
+### Comma-separated Arrays
+
+Use `@Header({ comma: true })` to serialize arrays as a **comma-separated string**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class CommaHeaderFrame extends JinFrame {
+  @Header({ comma: true })
+  declare readonly 'X-Tags'?: string[];
+}
+
+await CommaHeaderFrame.of({ 'X-Tags': ['red', 'blue', 'green'] }).execute();
+// → X-Tags: red,blue,green
+```
+
+### Bitwise OR Arrays (numbers only)
+
+Use `@Header({ bit: { enable: true } })` to serialize numeric arrays as a **bitwise OR sum**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags' })
+export class BitwiseHeaderFrame extends JinFrame {
+  @Header({ bit: { enable: true } })
+  declare readonly 'X-Flags'?: number[];
+}
+
+await BitwiseHeaderFrame.of({ 'X-Flags': [1, 2, 4] }).execute();
+// → X-Flags: 7   (1 | 2 | 4 = 7)
+```
+
+> Useful when the API expects bitmask values.
+
+## Header Value Encoding
+
+Unlike query strings, header values are **not percent-encoded**. All values are converted to **strings** (with formatters if needed) and sent as-is.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class EncodedHeaderFrame extends JinFrame {
+  @Header() declare readonly 'X-Note': string;
+}
+
+await EncodedHeaderFrame.of({ 'X-Note': 'hello & tea' }).execute();
+// → X-Note: hello & tea
+```
+
+## Optional Headers
+
+If no value is provided, the header itself is **omitted**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items' })
+export class OptionalHeaderFrame extends JinFrame {
+  @Header() declare readonly 'X-Trace'?: string;
+  @Header() declare readonly 'X-Page'?: number;
+}
+
+await OptionalHeaderFrame.of({}).execute();
+// → no X-Trace / X-Page headers
+```
+
+## Combining with Params & Query
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class ListUsersHeaderFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Query() declare readonly page?: number;
+  @Header() declare readonly Authorization: string;
+}
+
+await ListUsersHeaderFrame.of({
+  orgId: 'acme',
+  page: 1,
+  Authorization: 'Bearer token',
+}).execute();
+// → GET /orgs/acme/users?page=1
+// → Authorization: Bearer token
+```
+
+## Debugging Tip
+
+Right before sending the request, you can check the **final header map** using `frame.getData('header')`.
+
+```ts
+const frame = SearchFrame.of({
+  Authorization: 'Bearer token',
+  'X-Tags': ['red', 'blue'],
+});
+const req = frame.request();
+
+console.log(frame.getData('header')); // { Authorization: 'Bearer token', 'X-Tags': ['red','blue'] } (raw before serialization)
+console.log(req.headers); // serialized & flattened headers
+```

--- a/packages/jin-frame/docs/field/objectbody.md
+++ b/packages/jin-frame/docs/field/objectbody.md
@@ -1,0 +1,153 @@
+---
+outline: deep
+---
+
+# ObjectBody
+
+In **`jin-frame`**, when you declare a class field with the `@ObjectBody()` decorator, the entire object is **serialized into the HTTP Request Body** and sent as-is. This is useful when you want to handle a whole object at once rather than splitting it into multiple `@Body()` fields.
+
+## Quick Example
+
+```ts
+interface IUser {
+  username: string;
+  age?: number;
+  tags?: string[];
+  isAdmin?: boolean;
+}
+
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class CreateUserFrame extends JinFrame {
+  @ObjectBody() declare readonly user: IUser;
+}
+
+// Execute
+const frame = CreateUserFrame.of({
+  user: { username: 'pikachu', age: 7, tags: ['red', 'blue'], isAdmin: false },
+});
+const reply = await frame.execute();
+
+console.log(reply.config.data);
+// { "username": "pikachu", "age": 7, "tags": ["red","blue"], "isAdmin": false }
+```
+
+## Difference: Body vs ObjectBody
+
+| Category     | `@Body`                                  | `@ObjectBody`                                |
+| ------------ | ---------------------------------------- | -------------------------------------------- |
+| Declaration  | Define each field individually           | Define the entire object as a single field   |
+| Usage        | `@Body() declare readonly name: string;` | `@ObjectBody() declare readonly user: User;` |
+| Serialization| Multiple fields are merged into the body | The declared object is serialized as-is      |
+| Use Case     | APIs focusing on simple fields           | Passing a full DTO/interface in one shot     |
+
+## Nested Objects
+
+`@ObjectBody()` also supports nested object structures and serializes them as-is.
+
+```ts
+interface IProfile {
+  name: string;
+  age: number;
+}
+
+interface IUserSettings {
+  theme: string;
+  notifications: boolean;
+}
+
+interface IUser {
+  profile: IProfile;
+  settings?: IUserSettings;
+}
+
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class NestedUserFrame extends JinFrame {
+  @ObjectBody() declare readonly user: IUser;
+}
+
+const reply = await NestedUserFrame.of({
+  user: {
+    profile: { name: 'pikachu', age: 7 },
+    settings: { theme: 'dark', notifications: true },
+  },
+}).execute();
+
+// Body → { "profile": { "name": "pikachu", "age": 7 }, "settings": { "theme": "dark", "notifications": true } }
+```
+
+---
+
+## Array Support
+
+Objects containing arrays are serialized as-is.
+
+```ts
+interface IBatch {
+  ids: number[];
+}
+
+@Post({ host: 'https://api.example.com', path: '/batch' })
+export class BatchFrame extends JinFrame {
+  @ObjectBody() declare readonly data: IBatch;
+}
+
+const reply = await BatchFrame.of({ data: { ids: [1, 2, 3] } }).execute();
+// Body → { "ids": [1,2,3] }
+```
+
+## Optional Fields
+
+If a value inside the object is `undefined` or `null`, it is automatically omitted.
+
+```ts
+interface IUser {
+  username: string;
+  nickname?: string;
+}
+
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class OptionalUserFrame extends JinFrame {
+  @ObjectBody() declare readonly user: IUser;
+}
+
+const reply = await OptionalUserFrame.of({ user: { username: 'pikachu' } }).execute();
+// Body → { "username": "pikachu" }
+```
+
+## Combining with Params & Headers
+
+```ts
+interface IUser {
+  username: string;
+  age: number;
+}
+
+@Post({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class CreateUserInOrgFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Header() declare readonly Authorization: string;
+  @ObjectBody() declare readonly user: IUser;
+}
+
+const reply = await CreateUserInOrgFrame.of({
+  orgId: 'acme',
+  Authorization: 'Bearer token',
+  user: { username: 'pikachu', age: 7 },
+}).execute();
+
+// POST /orgs/acme/users
+// Headers: { Authorization: "Bearer token" }
+// Body: { "username": "pikachu", "age": 7 }
+```
+
+## Debugging Tip
+
+Right before sending the request, you can check the **final body data** with `frame.getData('body')`.
+
+```ts
+const frame = CreateUserFrame.of({ user: { username: 'pikachu', age: 7 } });
+const req = frame.request();
+
+console.log(frame.getData('body')); // { username: 'pikachu', age: 7 }
+console.log(req.data); // Final serialized body
+```

--- a/packages/jin-frame/docs/field/param.md
+++ b/packages/jin-frame/docs/field/param.md
@@ -1,0 +1,152 @@
+---
+outline: deep
+---
+
+# Param
+
+In **`jin-frame`**, when you declare a class field with the `@Param()` decorator, the field value is **bound to the URL path parameter** and included in the request.
+
+## Quick Example
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/users/:userId/posts/:postId' })
+export class UserPostFrame extends JinFrame {
+  @Param() declare readonly userId: string;
+  @Param() declare readonly postId: number;
+}
+
+// Execute
+const frame = UserPostFrame.of({ userId: 'alice', postId: 42 });
+const reply = await frame.execute();
+
+// Final URL:
+// https://api.example.com/users/alice/posts/42
+```
+
+## Supported Types & Serialization
+
+The types supported by `@Param()` and their serialized results are as follows:
+
+| Type                 | Option  | Example Value      | Serialized Result (in Path)    |
+| -------------------- | ------- | ------------------ | ------------------------------ |
+| `string`             |         | `'alice'`          | `/users/alice`                 |
+| `number`             |         | `42`               | `/posts/42`                    |
+| `boolean`            |         | `true`             | `/flags/true`                  |
+| `string[]`           | comma ✗ | `['a','b']`        | `/users/"[\"a\",\"b\"]"`       |
+| `string[]`           | comma ✓ | `['a','b']`        | `/users/a,b`                   |
+| `number[]`           | bit ✗   | `[1,2,4]`          | `/users/"[\"1\",\"2\",\"3\"]"` |
+| `number[]`           | bit ✓   | `[1,2,4]`          | `/users/7`                     |
+| `Date` + formatter   |         | `new Date(...)`    | `/date/2025-08-21`             |
+| `undefined` / `null` |         | `undefined`/`null` | **Error** (incomplete path)    |
+
+- Path parameters do **not** allow `undefined` or `null`. If a value is missing, an **exception will be thrown**.
+- By default, all values are converted to strings and URL-safe encoded.
+
+## Array Options
+
+### Default Array Serialization (Raw Arrays)
+
+Arrays without options are serialized as JSON-like strings.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/users/:tags' })
+export class ArrayParamFrame extends JinFrame {
+  @Param() declare readonly tags?: string[];
+}
+
+await ArrayParamFrame.of({ tags: ['red', 'blue'] }).execute();
+// → /users/"[\"red\",\"blue\"]"
+```
+
+### Comma-Separated Arrays
+
+Use `@Param({ comma: true })` to serialize arrays as **comma-separated values**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/users/:tags' })
+export class CommaParamFrame extends JinFrame {
+  @Param({ comma: true })
+  declare readonly tags?: string[];
+}
+
+await CommaParamFrame.of({ tags: ['red', 'blue', 'green'] }).execute();
+// → /users/red,blue,green
+```
+
+### Bitwise OR Arrays (Numbers Only)
+
+Use `@Param({ bit: { enable: true } })` to serialize numeric arrays as a **bitwise OR sum**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags/:flags' })
+export class BitwiseParamFrame extends JinFrame {
+  @Param({ bit: { enable: true } })
+  declare readonly flags?: number[];
+}
+
+await BitwiseParamFrame.of({ flags: [1, 2, 4] }).execute();
+// → /flags/7   (1 | 2 | 4 = 7)
+```
+
+> Useful when the API expects bitmask values.
+
+## Param Encoding
+
+All param values are URL-safe encoded.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/tags/:tag' })
+export class EncodedParamFrame extends JinFrame {
+  @Param() declare readonly tag: string;
+}
+
+await EncodedParamFrame.of({ tag: 'hello world & tea' }).execute();
+// → /tags/hello%20world%20%26%20tea
+```
+
+## Optional Params? (Not Allowed)
+
+Path parameters are always **required**. Missing values result in an **error** because the URL cannot be built.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items/:id' })
+export class OptionalParamFrame extends JinFrame {
+  @Param() declare readonly id?: number;
+}
+
+await OptionalParamFrame.of({}).execute();
+// → Error (missing id)
+```
+
+## Combining with Query & Header
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/orgs/:orgId/users/:userId' })
+export class ListUsersParamFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Param() declare readonly userId: string;
+  @Query() declare readonly page?: number;
+  @Header() declare readonly Authorization: string;
+}
+
+await ListUsersParamFrame.of({
+  orgId: 'acme',
+  userId: 'alice',
+  page: 1,
+  Authorization: 'Bearer token',
+}).execute();
+// → GET /orgs/acme/users/alice?page=1
+// → Authorization: Bearer token
+```
+
+## Debugging Tip
+
+Right before sending the request, you can check the **final param map** with `frame.getData('param')`.
+
+```ts
+const frame = UserPostFrame.of({ userId: 'alice', postId: 42 });
+const req = frame.request();
+
+console.log(frame.getData('param')); // { userId: 'alice', postId: 42 }
+console.log(req.url); // https://api.example.com/users/alice/posts/42
+```

--- a/packages/jin-frame/docs/field/query.md
+++ b/packages/jin-frame/docs/field/query.md
@@ -1,0 +1,154 @@
+---
+outline: deep
+---
+
+# Querystring
+
+In `jin-frame`, when you declare a class field with the `@Query()` decorator, the field value is **serialized into the URL querystring** and included in the request.
+
+## Quick Example
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class SearchFrame extends JinFrame {
+  @Query() declare readonly q: string;
+  @Query() declare readonly page?: number;
+  @Query() declare readonly tags?: string[]; // → ?tags=red&tags=blue
+  @Query() declare readonly debug?: boolean; // → ?debug=true
+}
+
+// Execute
+const frame = SearchFrame.of({ q: 'pikachu', page: 2, tags: ['red', 'blue'], debug: true });
+const reply = await frame.execute();
+
+console.log(reply.config.url);
+// https://api.example.com/search?q=pikachu&page=2&tags=red&tags=blue&debug=true
+```
+
+## Supported Types & Serialization
+
+The types supported by `@Query()` and their URL serialization results are as follows:
+
+<!-- markdownlint-disable MD033 -->
+
+| Type                 | Option  | Example value      | Serialized form                      |
+| -------------------- | ------- | ------------------ | ------------------------------------ |
+| `string`             |         | `'pikachu'`        | `?q=pikachu`                         |
+| `number`             |         | `2`                | `?page=2`                            |
+| `boolean`            |         | `true`             | `?debug=true`                        |
+| `string[]`           | comma ✗ | `['a','b']`        | `?tags=a&tags=b`                     |
+| `string[]`           | comma ✓ | `['a','b']`        | `?tags=a,b`                          |
+| `number[]`           | bit ✗   | `[1,2,4]`          | `?ids=1&ids=2&ids=4`                 |
+| `number[]`           | bit ✓   | `[1,2,4]`          | `?ids=7`<br />(bitwise OR: 1\|2\|4=7)|
+| `undefined` / `null` |         | `undefined`/`null` | **omitted**<br />(query key not created) |
+
+<!-- markdownlint-ensable MD033 -->
+
+- Default array serialization uses **repeated keys**.
+- Numbers/booleans are converted to strings before being sent.
+- `undefined` / `null` values are automatically omitted.
+
+## Array Options
+
+### Default Array Serialization (Repeated Keys)
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class ArrayQueryFrame extends JinFrame {
+  @Query() declare readonly tags?: string[];
+}
+
+const reply = await ArrayQueryFrame.of({ tags: ['red', 'blue'] }).execute();
+// → ?tags=red&tags=blue
+```
+
+### Comma-separated Arrays
+
+Use the `@Query({ comma: true })` option to serialize arrays as **comma-separated strings**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class CommaQueryFrame extends JinFrame {
+  @Query({ comma: true })
+  declare readonly tags?: string[];
+}
+
+const reply = await CommaQueryFrame.of({ tags: ['red', 'blue', 'green'] }).execute();
+// → ?tags=red,blue,green
+```
+
+### Bitwise OR Arrays (numbers only)
+
+Use `@Query({ bit: { enable: true } })` to serialize numeric arrays as a **bitwise OR sum**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags' })
+export class BitwiseQueryFrame extends JinFrame {
+  @Query({ bit: { enable: true } })
+  declare readonly flags?: number[];
+}
+
+const reply = await BitwiseQueryFrame.of({ flags: [1, 2, 4] }).execute();
+// → ?flags=7   (1 | 2 | 4 = 7)
+```
+
+> Useful when the API expects bitmask values.
+
+## URL Encoding
+
+All keys and values are safely **URL encoded** before being added to the URL.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class EncodedFrame extends JinFrame {
+  @Query() declare readonly q: string;
+}
+
+const reply = await EncodedFrame.of({ q: 'hello world & tea' }).execute();
+// → ?q=hello%20world%20%26%20tea
+```
+
+## Optional Queries
+
+If the value is missing, the query key is **omitted**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items' })
+export class OptionalQueryFrame extends JinFrame {
+  @Query() declare readonly q?: string;
+  @Query() declare readonly page?: number;
+}
+
+const reply = await OptionalQueryFrame.of({}).execute();
+// → https://api.example.com/items   (no query)
+```
+
+## Combining with Params & Headers
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class ListUsersFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Query() declare readonly page?: number;
+  @Header() declare readonly Authorization: string;
+}
+
+const reply = await ListUsersFrame.of({
+  orgId: 'acme',
+  page: 1,
+  Authorization: 'Bearer token',
+}).execute();
+// → GET /orgs/acme/users?page=1
+```
+
+## Debugging Tip
+
+Right before sending the request, you can use `frame.getData('query')` to check the **final query map**.
+
+```ts
+const frame = SearchFrame.of({ q: 'pikachu', tags: ['red', 'blue'] });
+const req = frame.request();
+
+console.log(frame.getData('query')); // { q: 'pikachu', tags: ['red','blue'] }
+console.log(req.url); // final URL
+```

--- a/packages/jin-frame/docs/getting-to-start.md
+++ b/packages/jin-frame/docs/getting-to-start.md
@@ -1,0 +1,146 @@
+---
+outline: deep
+---
+
+# Getting To Start
+
+## Installation
+
+npm
+
+```sh
+npm install jin-frame --save
+```
+
+yarn
+
+```sh
+yarn add jin-frame --save
+```
+
+pnpm
+
+```sh
+pnpm add jin-frame --save
+```
+
+## Quick Example
+
+```ts
+import { Get, Param, Query, JinFrame } from 'jin-frame';
+import { randomUUID } from 'node:crypto';
+
+@Get({ 
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/:name',
+})
+export class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+
+  @Query()
+  declare public readonly tid: string;
+}
+
+(async () => {
+  const frame = PokemonFrame.of({ 
+    name: 'pikachu', 
+    tid: randomUUID(),
+  });
+  const reply = await frame.execute();
+  
+  // Show Pikachu Data
+  console.log(reply.data);
+})();
+```
+
+## Customization Examples
+
+You can apply different settings for each endpoint.
+
+```ts
+import { Get, Param, Query, JinFrame, Timeout, Retry } from 'jin-frame';
+
+@Timeout(10_000)  // 10s timeout
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon',
+})
+class PokemonPagingFrame extends JinFrame {
+  @Query()
+  declare public readonly limit: number;
+
+  @Query()
+  declare public readonly offset: number;
+}
+
+@Retry({ max: 3, interval: 1000 }) // retry up to 3 times, 1s interval
+@Timeout(2_000)  // 2s timeout
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/:name',
+})
+export class PokemonDetailFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+}
+```
+
+## Why `declare public readonly`?
+
+When defining Frame classes in jin-frame, fields typically use `declare public readonly`.
+
+```ts
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+
+  @Query()
+  declare public readonly limit?: number;
+}
+```
+
+### Reasons
+
+1. **`declare`**  
+   - In TypeScript, the `declare` keyword means “this field has no value assigned directly, but only its type is declared.”  
+   - The actual value is injected at runtime by `jin-frame`, so there’s no need to initialize it inside the class.
+
+2. **`public`**  
+   - Explicitly specifies that the API field is an **input value** accessible from outside.
+
+3. **`readonly`**  
+   - Ensures immutability since the value should not change once defined.  
+   - Example: `@Param() name` is injected at creation time and will not change during execution.
+
+## Requirements
+
+### Decorator
+
+1. TypeScript
+1. Decorator
+   - Enable the `experimentalDecorators` and `emitDecoratorMetadata` options in your `tsconfig.json`.
+
+```jsonc
+{
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    // enable experimentalDecorators, emitDecoratorMetadata for using decorator
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+  },
+}
+```
+
+### Axios version
+
+| jin-frame | axios     |
+| --------- | --------- |
+| 2.x       | <= 0.27.x |
+| 3.x       | >= 1.1.x  |
+| 4.x       | >= 1.4.x  |
+
+### Summary
+
+`declare public readonly` ensures **type safety** and **immutability**, while letting jin-frame populate values automatically at runtime. This is the idiomatic pattern in jin-frame, and it is recommended to always use this syntax when defining fields.

--- a/packages/jin-frame/docs/index.md
+++ b/packages/jin-frame/docs/index.md
@@ -1,0 +1,39 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: 'jin-frame'
+  text: 'Declarative API definition'
+  tagline: A reusable, declarative, type-safe, and extendable HTTP request library.
+  image:
+    src: /assets/jin-frame-brand-icon.png
+    alt: jin-frame
+  actions:
+    - theme: brand
+      text: What is Jin-Frame?
+      link: /what-is-jin-frame
+    - theme: alt
+      text: Getting to Start
+      link: /getting-to-start
+    - theme: alt
+      text: Github
+      link: https://github.com/imjuni/jin-frame
+
+features:
+  - title: Declarative API Definition
+    icon: 🎩
+    details: Define URL, Querystring, Path Parameters, Body, and Headers intuitively using classes and decorators.
+  - title: Type Safety
+    icon: ⛑️
+    details: Use TypeScript’s type system to detect type mismatches at compile time.
+  - title: Support for Retry, Hooks, File Upload, Timeout and Mocking
+    icon: 🎢
+    details: Provides essential features for real-world usage, including Retry, Hooks, File Upload, Timeout and Mocking.
+  - title: Build upon the Axios Ecosystem
+    icon: 🏭
+    details:
+  - title: Path Parameter Support
+    icon: 🎪
+    details: Supports path parameter substitution via URLs, e.g., example.com/:id.
+---

--- a/packages/jin-frame/docs/ko/field/body.md
+++ b/packages/jin-frame/docs/ko/field/body.md
@@ -1,0 +1,162 @@
+---
+outline: deep
+---
+
+# Body
+
+`jin-frame`에서는 클래스 필드에 `@Body()` 데코레이터를 선언하면, 해당 필드 값이 **HTTP Request Body**에 직렬화되어 포함됩니다. 주로 `POST`, `PUT`, `PATCH` 요청에서 사용되며, JSON 직렬화를 기본으로 지원합니다.
+
+## Quick Example
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class CreateUserFrame extends JinFrame {
+  @Body() declare readonly username: string;
+  @Body() declare readonly age?: number;
+  @Body() declare readonly tags?: string[];
+  @Body() declare readonly isAdmin?: boolean;
+}
+
+// Execute
+const frame = CreateUserFrame.of({ username: 'pikachu', age: 7, tags: ['red', 'blue'], isAdmin: false });
+const reply = await frame.execute();
+
+console.log(reply.config.data);
+// { "username": "pikachu", "age": 7, "tags": ["red","blue"], "isAdmin": false }
+```
+
+## 구조 정의 방식
+
+`@Body()`는 Body에 전달되는 객체를 **필드 단위로 분해하여 정의**합니다. 예를 들어 다음과 같은 타입이 있다고 가정해 보겠습니다.
+
+```ts
+interface IamBody {
+  name: string;
+  age: number;
+}
+```
+
+이를 `@Body()`로 정의하면 다음과 같이 필드를 나누어 선언합니다.
+
+## 차이점: Body vs ObjectBody
+
+| 구분        | `@Body`                                  | `@ObjectBody`                                |
+| ----------- | ---------------------------------------- | -------------------------------------------- |
+| 선언 방식   | 각 필드를 개별적으로 정의                | 객체 전체를 단일 필드로 정의                 |
+| 사용 예시   | `@Body() declare readonly name: string;` | `@ObjectBody() declare readonly user: User;` |
+| 직렬화 결과 | 여러 필드가 병합되어 Body를 구성         | 필드에 선언한 객체를 그대로 Body로 직렬화    |
+| 활용 상황   | 단순한 필드 위주의 API 요청              | DTO/인터페이스 전체를 한 번에 Body로 전달    |
+
+## Supported Types & Serialization
+
+`@Body()`가 지원하고 JSON 직렬화되는 타입:
+
+| Type                 | Example value      | Serialized form                |
+| -------------------- | ------------------ | ------------------------------ |
+| `string`             | `'pikachu'`        | `"pikachu"`                    |
+| `number`             | `2`                | `2`                            |
+| `boolean`            | `true`             | `true`                         |
+| `string[]`           | `['a','b']`        | `["a","b"]`                    |
+| `number[]`           | `[1,2,4]`          | `[1,2,4]`                      |
+| `object`             | `{ key: "value" }` | `{ "key": "value" }`           |
+| `undefined` / `null` | `undefined`/`null` | **omitted** (키 자체가 생략됨) |
+
+- `undefined` / `null` 값은 기본적으로 생략 처리됩니다.
+- 배열, 객체도 그대로 JSON 변환됩니다.
+
+```ts
+@Post({ host: 'https://api.someapi.com', path: '/api/some/path' })
+class PostFrameExample extends JinFrame {
+  @Body()
+  declare public readonly name: string;
+
+  @Body()
+  declare public readonly age: number;
+}
+```
+
+즉, `IamBody`의 속성(`name`, `age`)을 각각의 `@Body` 데코레이터로 분리해 선언하는 방식입니다. 만약 하나의 필드로 `IamBody` 전체를 다루고 싶다면 `@Body` 대신 **`@ObjectBody`** 데코레이터를 사용하면 됩니다.
+
+## Nested Objects
+
+중첩된 객체도 직렬화 가능합니다.
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class NestedBodyFrame extends JinFrame {
+  @Body() declare readonly profile: { name: string; age: number };
+  @Body() declare readonly settings?: { theme: string; notifications: boolean };
+}
+
+const reply = await NestedBodyFrame.of({
+  profile: { name: 'pikachu', age: 7 },
+  settings: { theme: 'dark', notifications: true },
+}).execute();
+
+// Body → { "profile": { "name": "pikachu", "age": 7 }, "settings": { "theme": "dark", "notifications": true } }
+```
+
+## Array Options
+
+배열은 JSON 배열 형태로 직렬화됩니다.  
+쿼리스트링과 달리 `comma`, `bitwise` 옵션은 필요하지 않습니다.
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/batch' })
+export class ArrayBodyFrame extends JinFrame {
+  @Body() declare readonly ids: number[];
+}
+
+const reply = await ArrayBodyFrame.of({ ids: [1, 2, 3] }).execute();
+// Body → { "ids": [1,2,3] }
+```
+
+## Optional Fields
+
+값이 없으면 Body에서 해당 키는 **자동 생략**됩니다.
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class OptionalBodyFrame extends JinFrame {
+  @Body() declare readonly username: string;
+  @Body() declare readonly nickname?: string;
+}
+
+const reply = await OptionalBodyFrame.of({ username: 'pikachu' }).execute();
+// Body → { "username": "pikachu" }
+```
+
+## Combining with Params & Headers
+
+```ts
+@Post({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class CreateUserInOrgFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Header() declare readonly Authorization: string;
+  @Body() declare readonly username: string;
+  @Body() declare readonly age: number;
+}
+
+const reply = await CreateUserInOrgFrame.of({
+  orgId: 'acme',
+  Authorization: 'Bearer token',
+  username: 'pikachu',
+  age: 7,
+}).execute();
+
+// POST /orgs/acme/users
+// Headers: { Authorization: "Bearer token" }
+// Body: { "username": "pikachu", "age": 7 }
+```
+
+## Debugging Tip
+
+요청 직전에 `frame.getData('body')`로 **최종 Body 데이터**를 확인할 수 있습니다.
+
+```ts
+const frame = CreateUserFrame.of({ username: 'pikachu', age: 7 });
+const req = frame.request();
+
+console.log(frame.getData('body')); // { username: 'pikachu', age: 7 }
+console.log(req.data); // 최종 직렬화된 Body
+```

--- a/packages/jin-frame/docs/ko/field/formatters.md
+++ b/packages/jin-frame/docs/ko/field/formatters.md
@@ -1,0 +1,220 @@
+# Formatters
+
+`@Query()`, `@Param()`, `@Body()`, `@ObjectBody()`, `@Header()` 데코레이터는 값이 직렬화되기 전에 가공할 수 있도록 **formatters** 옵션을 제공합니다.
+
+처리 순서는 다음과 같습니다
+
+- `@Query()`, `@Param()`, `@Header()`
+  - **값 수집 → formatter 적용(순차 체인) → 배열 옵션(comma/bit) 적용 → URL 인코딩**
+- `@Body()`, `@ObjectBody()`
+  - **값 수집 → formatter 적용(순차 체인)**
+
+> 규칙
+>
+> - `undefined` 또는 `null`을 반환하면 해당 키는 **생략**됩니다.
+> - **배열 필드**의 경우 formatter는 **각 요소별로 개별 적용**됩니다.
+> - `formatters`는 단일 객체 또는 **여러 객체 배열(순차 적용)** 로 지정할 수 있습니다.
+> - 반환값은 원시값(string/number/boolean) 또는 배열일 수 있습니다.
+> - 예: **string → Date → epoch time** 과 같은 단계적 변환을 체인으로 연결할 수 있습니다.
+
+## Formatter Options
+
+| 필드명        | 타입                                          | 설명                                                                                                                                 |
+| ------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `order`       | `('string' \| 'number' \| 'dateTime')[]`      | 포맷터 적용 순서를 지정합니다. 기본값은 `['number', 'string', 'dateTime']` 입니다.                                                   |
+| `ignoreError` | `boolean`                                     | 변환 중 오류가 발생했을 때 값을 버릴지 여부를 설정합니다. `true`이면 오류를 무시하고 값을 제외하며, `false`이면 예외를 발생시킵니다. |
+| `number`      | `(value: number) => number \| Date \| string` | 숫자 값을 변환하는 함수입니다. 반환값은 `number`, `Date`, `string` 중 하나일 수 있습니다.                                            |
+| `string`      | `(value: string) => string \| Date`           | 문자열 값을 변환하는 함수입니다. 반환값은 `string` 또는 `Date`입니다.                                                                |
+| `dateTime`    | `(value: Date) => string`                     | `Date` 객체를 문자열로 변환하는 함수입니다.                                                                                          |
+
+## 유의 사항
+
+Formatter는 지정된 입력 타입(`string`, `number`, `Date`)에 맞게 동작합니다. 입력값이 기대 타입과 일치하지 않으면 변환이 수행되지 않거나, 값이 생략될 수 있습니다.
+
+- 변환이 되지 않는 경우 먼저 **입력값의 타입이 올바른지 확인**하세요.
+- 필요한 경우 `ignoreError` 옵션을 활용해 예외를 무시하고 안전하게 값을 제외할 수 있습니다.
+
+## 단일 값 포매팅
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class FormatterSingleFrame extends JinFrame {
+  @Query({
+    formatters: { string: (v: string) => v.trim().toLowerCase() }, // 문자열 → 소문자로 변환
+  })
+  declare readonly q?: string;
+
+  @Query({
+    formatters: { number: (v: number) => Number(v.toFixed(2)) }, // 숫자 → 소수점 둘째자리까지 반올림
+  })
+  declare readonly price?: number;
+
+  @Query({
+    formatters: {
+      dateTime: (d: Date) =>
+        `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`,
+    },
+    // Date → yyyy-MM-dd
+  })
+  declare readonly date?: Date;
+}
+
+const reply = await FormatterSingleFrame.of({
+  q: '  Pikachu ',
+  price: 12.345,
+  date: new Date('2025-08-21'),
+}).execute();
+// → ?q=pikachu&price=12.35&date=2025-08-21
+```
+
+## 배열 요소 포매팅 (요소별 적용)
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class FormatterArrayFrame extends JinFrame {
+  @Query({
+    formatters: { string: (tag: string) => tag.trim().toLowerCase() }, // 배열의 각 요소에 적용
+  })
+  declare readonly tags?: string[];
+}
+
+const reply = await FormatterArrayFrame.of({ tags: ['  RED ', '  Blue'] }).execute();
+// → ?tags=red&tags=blue
+```
+
+## 다중 Formatter (체인 적용)
+
+### 배열로 formatter 여러 개 전달
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/convert' })
+export class FormatterChainFrame extends JinFrame {
+  @Query({
+    formatters: [
+      { string: (s: string) => s.trim() }, // string → trimmed string
+      { string: (s: string) => new Date(s) }, // string → Date
+      { dateTime: (d: Date) => `${Math.floor(d.getTime())}` }, // Date → epoch(ms)
+    ],
+  })
+  declare readonly dates?: string[];
+}
+
+const reply = await FormatterChainFrame.of({ dates: ['2025-08-01', '2025-08-02'] }).execute();
+// → ?dates=1754006400000&dates=1754092800000
+```
+
+### order 옵션 사용
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/convert' })
+export class FormatterChainFrame extends JinFrame {
+  @Query({
+    formatters: [
+      {
+        order: ['number', 'string', 'dateTime'], // number → string → dateTime 순서대로 실행
+        string: (s: string) => new Date(s.trim()), // string → Date
+        dateTime: (d: Date) => `${Math.floor(d.getTime())}`, // Date → epoch(ms)
+      },
+    ],
+  })
+  declare readonly dates?: string[];
+}
+```
+
+## 배열 + 쉼표 직렬화와 Formatters 동시 적용
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class FormatterCommaFrame extends JinFrame {
+  @Query({
+    comma: true, // 배열을 쉼표로 직렬화
+    formatters: { string: (tag: string) => `c-${tag.trim()}` }, // 각 요소 앞에 접두사 추가
+  })
+  declare readonly tags?: string[];
+}
+
+const reply = await FormatterCommaFrame.of({ tags: ['red', ' blue ', 'green,'] }).execute();
+// → ?tags=c-red,c-blue,c-green
+```
+
+## 숫자 배열 + 비트 OR 직렬화와 정규화
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags' })
+export class FormatterBitFrame extends JinFrame {
+  @Query({
+    bit: { enable: true }, // 비트 OR 직렬화 활성화
+    formatters: { number: (f?: number) => (Number.isFinite(f) && f! >= 0 ? Number(f) : undefined) },
+    // 음수나 NaN 값은 제외
+  })
+  declare readonly flags?: number[];
+}
+
+const reply = await FormatterBitFrame.of({ flags: [1, 2, 4] }).execute();
+// → ?flags=7
+```
+
+## Enum / 매핑 변환
+
+```ts
+const TAG_MAP: Record<string, string> = { red: 'R', blue: 'B', green: 'G' };
+
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class FormatterMapFrame extends JinFrame {
+  @Query({
+    formatters: { string: (tag?: string) => (tag ? TAG_MAP[tag] : undefined) }, // 매핑 변환
+  })
+  declare readonly tags?: string[];
+}
+
+const reply = await FormatterMapFrame.of({ tags: ['red', 'blue', 'green'] }).execute();
+// → ?tags=R&tags=B&tags=G
+```
+
+## @Body, @ObjectBody에서의 Formatter
+
+`@Body()`와 `@ObjectBody()`는 객체를 다루기 때문에, 객체의 어떤 필드에 formatter를 적용할지 명시해야 합니다.  
+이때 `findFrom` 옵션을 사용하여 **경로를 지정**합니다.
+
+```ts
+@Post({ host: 'http://some.api.google.com/jinframe/:passing' })
+class ObjectFormatterExample extends JinFrame {
+  @Param()
+  declare public readonly passing: string;
+
+  @ObjectBody({
+    formatters: [
+      {
+        findFrom: 'name', // 객체의 name 필드에 formatter 적용
+        string(value) {
+          return `${value}::111`;
+        },
+      },
+      {
+        findFrom: 'date', // 객체의 date 필드에 formatter 적용
+        dateTime(value) {
+          const f = lightFormat(value, 'yyyy-MM-dd');
+          return f;
+        },
+      },
+    ],
+  })
+  declare public readonly ability: {
+    name: string;
+    date: Date;
+    desc: string;
+  };
+}
+```
+
+## 결론
+
+formatter는 다양한 목적으로 사용할 수 있습니다:
+
+- 문자열 정규화
+- 날짜 변환
+- 배열 직렬화 최적화
+- 비트 마스크 처리
+- 매핑/열거형 변환
+
+특히 `@Body`, `@ObjectBody`에서도 DTO 객체 단위로 세밀한 제어가 가능하여, 복잡한 API 요청도 선언적으로 깔끔하게 관리할 수 있습니다.

--- a/packages/jin-frame/docs/ko/field/header.md
+++ b/packages/jin-frame/docs/ko/field/header.md
@@ -1,0 +1,169 @@
+---
+outline: deep
+---
+
+# Header
+
+`jin-frame`에서 클래스 필드에 `@Header()` 데코레이터를 선언하면, 해당 필드 값이 **HTTP 헤더로 직렬화**되어 요청에 포함됩니다.
+
+## 간단한 예제
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class SearchFrame extends JinFrame {
+  @Header() declare readonly Authorization: string;
+  @Header() declare readonly 'X-Tracking-Id'?: string;
+  @Header() declare readonly 'X-Tags'?: string[]; // → X-Tags: red (반복)  X-Tags: blue
+  @Header() declare readonly 'X-Debug'?: boolean; // → X-Debug: true
+}
+
+// 실행
+const frame = SearchFrame.of({
+  Authorization: 'Bearer token',
+  'X-Tracking-Id': '1234',
+  'X-Tags': ['red', 'blue'],
+  'X-Debug': true,
+});
+const reply = await frame.execute();
+
+// 전송된 헤더:
+// Authorization: Bearer token
+// X-Tracking-Id: 1234
+// X-Tags: red
+// X-Tags: blue
+// X-Debug: true
+```
+
+## 지원 타입과 직렬화 방식
+
+`@Header()`가 지원하는 타입과 직렬화 결과는 다음과 같습니다.
+
+<!-- markdownlint-disable MD033 -->
+
+| 타입                 | 옵션    | 예제 값            | 직렬화 결과 (헤더 라인)                  |
+| -------------------- | ------- | ------------------ | ---------------------------------------- |
+| `string`             |         | `'token'`          | `X-Auth: token`                          |
+| `number`             |         | `2`                | `X-Page: 2`                              |
+| `boolean`            |         | `true`             | `X-Debug: true`                          |
+| `string[]`           | comma ✗ | `['a','b']`        | `X-Tags: "[\"a\", \"b\"]"`               |
+| `string[]`           | comma ✓ | `['a','b']`        | `X-Tags: a,b`                            |
+| `number[]`           | bit ✗   | `[1,2,4]`          | `X-Flags: "[\"1\", \"2\", \"4\"]"`       |
+| `number[]`           | bit ✓   | `[1,2,4]`          | `X-Flags: 7`<br />(비트 OR: 1\|2\|4 = 7) |
+| `undefined` / `null` |         | `undefined`/`null` | **생략됨** (헤더 생성 안 됨)             |
+
+<!-- markdownlint-ensable MD033 -->
+
+- 배열 기본 직렬화는 **반복 헤더** 방식입니다.
+- 숫자/불리언은 문자열로 변환되어 전송됩니다.
+- `undefined` / `null` 값은 자동으로 생략됩니다.
+
+## 배열 옵션
+
+### 기본 배열 직렬화 (반복 헤더)
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class ArrayHeaderFrame extends JinFrame {
+  @Header() declare readonly 'X-Tags'?: string[];
+}
+
+await ArrayHeaderFrame.of({ 'X-Tags': ['red', 'blue'] }).execute();
+// → X-Tags: red
+// → X-Tags: blue
+```
+
+### 쉼표 구분 배열
+
+`@Header({ comma: true })`를 사용하면 배열이 **쉼표 구분 문자열**로 직렬화됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class CommaHeaderFrame extends JinFrame {
+  @Header({ comma: true })
+  declare readonly 'X-Tags'?: string[];
+}
+
+await CommaHeaderFrame.of({ 'X-Tags': ['red', 'blue', 'green'] }).execute();
+// → X-Tags: red,blue,green
+```
+
+### 비트 OR 배열 (숫자 전용)
+
+`@Header({ bit: { enable: true } })`를 사용하면 숫자 배열이 **비트 OR 합산 값**으로 직렬화됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags' })
+export class BitwiseHeaderFrame extends JinFrame {
+  @Header({ bit: { enable: true } })
+  declare readonly 'X-Flags'?: number[];
+}
+
+await BitwiseHeaderFrame.of({ 'X-Flags': [1, 2, 4] }).execute();
+// → X-Flags: 7   (1 | 2 | 4 = 7)
+```
+
+> API 서버가 비트 마스크 값을 요구할 때 유용합니다.
+
+## 헤더 값 인코딩
+
+쿼리스트링과 달리 헤더 값은 **퍼센트 인코딩되지 않습니다**.  
+모든 값은 문자열(필요 시 formatter 적용)로 변환되어 그대로 전송됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class EncodedHeaderFrame extends JinFrame {
+  @Header() declare readonly 'X-Note': string;
+}
+
+await EncodedHeaderFrame.of({ 'X-Note': 'hello & tea' }).execute();
+// → X-Note: hello & tea
+```
+
+## 선택적 헤더
+
+값이 없으면 해당 헤더는 **생성되지 않습니다**.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items' })
+export class OptionalHeaderFrame extends JinFrame {
+  @Header() declare readonly 'X-Trace'?: string;
+  @Header() declare readonly 'X-Page'?: number;
+}
+
+await OptionalHeaderFrame.of({}).execute();
+// → X-Trace, X-Page 헤더 없음
+```
+
+## Param, Query와 함께 사용하기
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class ListUsersHeaderFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Query() declare readonly page?: number;
+  @Header() declare readonly Authorization: string;
+}
+
+await ListUsersHeaderFrame.of({
+  orgId: 'acme',
+  page: 1,
+  Authorization: 'Bearer token',
+}).execute();
+// → GET /orgs/acme/users?page=1
+// → Authorization: Bearer token
+```
+
+## 디버깅 팁
+
+요청 직전에 `frame.getData('header')`를 사용해 **최종 헤더 맵**을 확인할 수 있습니다.
+
+```ts
+const frame = SearchFrame.of({
+  Authorization: 'Bearer token',
+  'X-Tags': ['red', 'blue'],
+});
+const req = frame.request();
+
+console.log(frame.getData('header')); // { Authorization: 'Bearer token', 'X-Tags': ['red','blue'] } (직렬화 전 원본)
+console.log(req.headers); // 직렬화된 최종 헤더
+```

--- a/packages/jin-frame/docs/ko/field/objectbody.md
+++ b/packages/jin-frame/docs/ko/field/objectbody.md
@@ -1,0 +1,153 @@
+---
+outline: deep
+---
+
+# ObjectBody
+
+`jin-frame`에서는 클래스 필드에 `@ObjectBody()` 데코레이터를 선언하면, 객체 전체를 **HTTP Request Body**로 직렬화하여 전송할 수 있습니다. 이는 여러 필드를 각각 `@Body()`로 분리하지 않고, 하나의 객체 단위로 관리하고 싶을 때 유용합니다.
+
+## Quick Example
+
+```ts
+interface IUser {
+  username: string;
+  age?: number;
+  tags?: string[];
+  isAdmin?: boolean;
+}
+
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class CreateUserFrame extends JinFrame {
+  @ObjectBody() declare readonly user: IUser;
+}
+
+// Execute
+const frame = CreateUserFrame.of({
+  user: { username: 'pikachu', age: 7, tags: ['red', 'blue'], isAdmin: false },
+});
+const reply = await frame.execute();
+
+console.log(reply.config.data);
+// { "username": "pikachu", "age": 7, "tags": ["red","blue"], "isAdmin": false }
+```
+
+## 차이점: Body vs ObjectBody
+
+| 구분        | `@Body`                                  | `@ObjectBody`                                |
+| ----------- | ---------------------------------------- | -------------------------------------------- |
+| 선언 방식   | 각 필드를 개별적으로 정의                | 객체 전체를 단일 필드로 정의                 |
+| 사용 예시   | `@Body() declare readonly name: string;` | `@ObjectBody() declare readonly user: User;` |
+| 직렬화 결과 | 여러 필드가 병합되어 Body를 구성         | 필드에 선언한 객체를 그대로 Body로 직렬화    |
+| 활용 상황   | 단순한 필드 위주의 API 요청              | DTO/인터페이스 전체를 한 번에 Body로 전달    |
+
+## Nested Objects
+
+`@ObjectBody()`는 중첩 객체를 포함한 구조도 그대로 직렬화합니다.
+
+```ts
+interface IProfile {
+  name: string;
+  age: number;
+}
+
+interface IUserSettings {
+  theme: string;
+  notifications: boolean;
+}
+
+interface IUser {
+  profile: IProfile;
+  settings?: IUserSettings;
+}
+
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class NestedUserFrame extends JinFrame {
+  @ObjectBody() declare readonly user: IUser;
+}
+
+const reply = await NestedUserFrame.of({
+  user: {
+    profile: { name: 'pikachu', age: 7 },
+    settings: { theme: 'dark', notifications: true },
+  },
+}).execute();
+
+// Body → { "profile": { "name": "pikachu", "age": 7 }, "settings": { "theme": "dark", "notifications": true } }
+```
+
+---
+
+## Array Support
+
+배열을 포함한 객체도 그대로 직렬화됩니다.
+
+```ts
+interface IBatch {
+  ids: number[];
+}
+
+@Post({ host: 'https://api.example.com', path: '/batch' })
+export class BatchFrame extends JinFrame {
+  @ObjectBody() declare readonly data: IBatch;
+}
+
+const reply = await BatchFrame.of({ data: { ids: [1, 2, 3] } }).execute();
+// Body → { "ids": [1,2,3] }
+```
+
+## Optional Fields
+
+객체 내부의 값이 `undefined` 또는 `null`이면 자동으로 생략됩니다.
+
+```ts
+interface IUser {
+  username: string;
+  nickname?: string;
+}
+
+@Post({ host: 'https://api.example.com', path: '/users' })
+export class OptionalUserFrame extends JinFrame {
+  @ObjectBody() declare readonly user: IUser;
+}
+
+const reply = await OptionalUserFrame.of({ user: { username: 'pikachu' } }).execute();
+// Body → { "username": "pikachu" }
+```
+
+## Combining with Params & Headers
+
+```ts
+interface IUser {
+  username: string;
+  age: number;
+}
+
+@Post({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class CreateUserInOrgFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Header() declare readonly Authorization: string;
+  @ObjectBody() declare readonly user: IUser;
+}
+
+const reply = await CreateUserInOrgFrame.of({
+  orgId: 'acme',
+  Authorization: 'Bearer token',
+  user: { username: 'pikachu', age: 7 },
+}).execute();
+
+// POST /orgs/acme/users
+// Headers: { Authorization: "Bearer token" }
+// Body: { "username": "pikachu", "age": 7 }
+```
+
+## Debugging Tip
+
+요청 직전에 `frame.getData('body')`로 **최종 Body 데이터**를 확인할 수 있습니다.
+
+```ts
+const frame = CreateUserFrame.of({ user: { username: 'pikachu', age: 7 } });
+const req = frame.request();
+
+console.log(frame.getData('body')); // { username: 'pikachu', age: 7 }
+console.log(req.data); // 최종 직렬화된 Body
+```

--- a/packages/jin-frame/docs/ko/field/param.md
+++ b/packages/jin-frame/docs/ko/field/param.md
@@ -1,0 +1,152 @@
+---
+outline: deep
+---
+
+# Param
+
+`jin-frame`에서 클래스 필드에 `@Param()` 데코레이터를 선언하면, 해당 필드 값이 **URL 경로 파라미터(Path Parameter)**로 바인딩되어 요청에 포함됩니다.
+
+## 간단한 예제
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/users/:userId/posts/:postId' })
+export class UserPostFrame extends JinFrame {
+  @Param() declare readonly userId: string;
+  @Param() declare readonly postId: number;
+}
+
+// 실행
+const frame = UserPostFrame.of({ userId: 'alice', postId: 42 });
+const reply = await frame.execute();
+
+// 최종 URL:
+// https://api.example.com/users/alice/posts/42
+```
+
+## 지원 타입과 직렬화 방식
+
+`@Param()`이 지원하는 타입과 직렬화 결과는 다음과 같습니다.
+
+| 타입                  | 옵션    | 예제 값           | 직렬화 결과 (경로 내)          |
+| --------------------- | ------- | ----------------- | ------------------------------ |
+| `string`              |         | `'alice'`         | `/users/alice`                 |
+| `number`              |         | `42`              | `/posts/42`                    |
+| `boolean`             |         | `true`            | `/flags/true`                  |
+| `string[]`            | comma ✗ | `['a','b']`       | `/users/"[\"a\",\"b\"]"`       |
+| `string[]`            | comma ✓ | `['a','b']`       | `/users/a,b`                   |
+| `number[]`            | bit ✗   | `[1,2,4]`         | `/users/"[\"1\",\"2\",\"3\"]"` |
+| `number[]`            | bit ✓   | `[1,2,4]`         | `/users/7`                     |
+| `Date` + formatter    |         | `new Date(...)`   | `/date/2025-08-21`             |
+| `undefined` / `null`  |         | `undefined`/`null`| **에러** (경로 불완전)         |
+
+- Path Param은 `undefined` 또는 `null` 값을 허용하지 않습니다. 값이 없으면 **예외가 발생**합니다.  
+- 기본적으로 모든 값은 문자열로 변환되고 URL-safe 인코딩됩니다.
+
+## 배열 옵션
+
+### 기본 배열 직렬화 (Raw 배열)
+
+옵션이 없는 배열은 JSON 문자열처럼 직렬화됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/users/:tags' })
+export class ArrayParamFrame extends JinFrame {
+  @Param() declare readonly tags?: string[];
+}
+
+await ArrayParamFrame.of({ tags: ['red', 'blue'] }).execute();
+// → /users/"[\"red\",\"blue\"]"
+```
+
+### 쉼표 구분 배열
+
+`@Param({ comma: true })`를 사용하면 배열이 **쉼표 구분 문자열**로 직렬화됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/users/:tags' })
+export class CommaParamFrame extends JinFrame {
+  @Param({ comma: true })
+  declare readonly tags?: string[];
+}
+
+await CommaParamFrame.of({ tags: ['red', 'blue', 'green'] }).execute();
+// → /users/red,blue,green
+```
+
+### 비트 OR 배열 (숫자 전용)
+
+`@Param({ bit: { enable: true } })`를 사용하면 숫자 배열이 **비트 OR 합산 값**으로 직렬화됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags/:flags' })
+export class BitwiseParamFrame extends JinFrame {
+  @Param({ bit: { enable: true } })
+  declare readonly flags?: number[];
+}
+
+await BitwiseParamFrame.of({ flags: [1, 2, 4] }).execute();
+// → /flags/7   (1 | 2 | 4 = 7)
+```
+
+> API 서버가 비트 마스크 값을 요구할 때 유용합니다.
+
+## Param 인코딩
+
+모든 파라미터 값은 URL-safe 인코딩됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/tags/:tag' })
+export class EncodedParamFrame extends JinFrame {
+  @Param() declare readonly tag: string;
+}
+
+await EncodedParamFrame.of({ tag: 'hello world & tea' }).execute();
+// → /tags/hello%20world%20%26%20tea
+```
+
+## Optional Param? (허용되지 않음)
+
+경로 파라미터는 항상 **필수 값**입니다. 값이 없으면 URL을 만들 수 없으므로 **에러**가 발생합니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items/:id' })
+export class OptionalParamFrame extends JinFrame {
+  @Param() declare readonly id?: number;
+}
+
+await OptionalParamFrame.of({}).execute();
+// → Error (id 누락)
+```
+
+## Query, Header와 함께 사용하기
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/orgs/:orgId/users/:userId' })
+export class ListUsersParamFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Param() declare readonly userId: string;
+  @Query() declare readonly page?: number;
+  @Header() declare readonly Authorization: string;
+}
+
+await ListUsersParamFrame.of({
+  orgId: 'acme',
+  userId: 'alice',
+  page: 1,
+  Authorization: 'Bearer token'
+}).execute();
+// → GET /orgs/acme/users/alice?page=1
+// → Authorization: Bearer token
+```
+
+## 디버깅 팁
+
+요청 직전에 `frame.getData('param')`을 사용해 **최종 Param 맵**을 확인할 수 있습니다.
+
+```ts
+const frame = UserPostFrame.of({ userId: 'alice', postId: 42 });
+const req = frame.request();
+
+console.log(frame.getData('param')); // { userId: 'alice', postId: 42 }
+console.log(req.url); // https://api.example.com/users/alice/posts/42
+```

--- a/packages/jin-frame/docs/ko/field/query.md
+++ b/packages/jin-frame/docs/ko/field/query.md
@@ -1,0 +1,154 @@
+---
+outline: deep
+---
+
+# Querystring
+
+`jin-frame`에서 클래스 필드에 `@Query()` 데코레이터를 선언하면 해당 필드 값이 **URL 쿼리스트링으로 직렬화**되어 요청에 포함됩니다.
+
+## 간단한 예제
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class SearchFrame extends JinFrame {
+  @Query() declare readonly q: string;
+  @Query() declare readonly page?: number;
+  @Query() declare readonly tags?: string[]; // → ?tags=red&tags=blue
+  @Query() declare readonly debug?: boolean; // → ?debug=true
+}
+
+// 실행
+const frame = SearchFrame.of({ q: 'pikachu', page: 2, tags: ['red', 'blue'], debug: true });
+const reply = await frame.execute();
+
+console.log(reply.config.url);
+// https://api.example.com/search?q=pikachu&page=2&tags=red&tags=blue&debug=true
+```
+
+## 지원 타입과 직렬화 방식
+
+`@Query()`가 지원하는 타입과 URL 직렬화 결과는 다음과 같습니다.
+
+<!-- markdownlint-disable MD033 -->
+
+| 타입                 | 옵션    | 예제 값            | 직렬화 결과                          |
+| -------------------- | ------- | ------------------ | ------------------------------------ |
+| `string`             |         | `'pikachu'`        | `?q=pikachu`                         |
+| `number`             |         | `2`                | `?page=2`                            |
+| `boolean`            |         | `true`             | `?debug=true`                        |
+| `string[]`           | comma ✗ | `['a','b']`        | `?tags=a&tags=b`                     |
+| `string[]`           | comma ✓ | `['a','b']`        | `?tags=a,b`                          |
+| `number[]`           | bit ✗   | `[1,2,4]`          | `?ids=1&ids=2&ids=4`                 |
+| `number[]`           | bit ✓   | `[1,2,4]`          | `?ids=7`<br />(비트 OR: 1\|2\|4 = 7) |
+| `undefined` / `null` |         | `undefined`/`null` | **생략됨**<br />(쿼리 키 생성 안 됨) |
+
+<!-- markdownlint-ensable MD033 -->
+
+- 배열 기본 직렬화는 **반복 키(repeated key)** 방식입니다.
+- 숫자/불리언 값은 문자열로 변환되어 전송됩니다.
+- `undefined` / `null`은 자동으로 생략됩니다.
+
+## 배열 옵션
+
+### 기본 배열 직렬화 (반복 키)
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class ArrayQueryFrame extends JinFrame {
+  @Query() declare readonly tags?: string[];
+}
+
+const reply = await ArrayQueryFrame.of({ tags: ['red', 'blue'] }).execute();
+// → ?tags=red&tags=blue
+```
+
+### 쉼표 구분 배열
+
+`@Query({ comma: true })` 옵션을 사용하면 배열을 **쉼표 구분 문자열**로 직렬화할 수 있습니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/filter' })
+export class CommaQueryFrame extends JinFrame {
+  @Query({ comma: true })
+  declare readonly tags?: string[];
+}
+
+const reply = await CommaQueryFrame.of({ tags: ['red', 'blue', 'green'] }).execute();
+// → ?tags=red,blue,green
+```
+
+### 비트 OR 배열 (숫자 전용)
+
+`@Query({ bit: { enable: true } })`를 사용하면 숫자 배열을 **비트 OR 합산 값**으로 직렬화할 수 있습니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/flags' })
+export class BitwiseQueryFrame extends JinFrame {
+  @Query({ bit: { enable: true } })
+  declare readonly flags?: number[];
+}
+
+const reply = await BitwiseQueryFrame.of({ flags: [1, 2, 4] }).execute();
+// → ?flags=7   (1 | 2 | 4 = 7)
+```
+
+> API 서버가 비트 마스크 값을 기대할 때 유용합니다.
+
+## URL 인코딩
+
+모든 키와 값은 URL에 추가되기 전에 안전하게 **URL 인코딩**됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/search' })
+export class EncodedFrame extends JinFrame {
+  @Query() declare readonly q: string;
+}
+
+const reply = await EncodedFrame.of({ q: 'hello world & tea' }).execute();
+// → ?q=hello%20world%20%26%20tea
+```
+
+## 선택적 쿼리
+
+값이 없으면 해당 쿼리 키는 **생략**됩니다.
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/items' })
+export class OptionalQueryFrame extends JinFrame {
+  @Query() declare readonly q?: string;
+  @Query() declare readonly page?: number;
+}
+
+const reply = await OptionalQueryFrame.of({}).execute();
+// → https://api.example.com/items   (쿼리 없음)
+```
+
+## Param, Header와 함께 사용하기
+
+```ts
+@Get({ host: 'https://api.example.com', path: '/orgs/:orgId/users' })
+export class ListUsersFrame extends JinFrame {
+  @Param() declare readonly orgId: string;
+  @Query() declare readonly page?: number;
+  @Header() declare readonly Authorization: string;
+}
+
+const reply = await ListUsersFrame.of({
+  orgId: 'acme',
+  page: 1,
+  Authorization: 'Bearer token',
+}).execute();
+// → GET /orgs/acme/users?page=1
+```
+
+## 디버깅 팁
+
+요청 직전에 `frame.getData('query')`를 사용해 최종 쿼리 맵을 확인할 수 있습니다.
+
+```ts
+const frame = SearchFrame.of({ q: 'pikachu', tags: ['red', 'blue'] });
+const req = frame.request();
+
+console.log(frame.getData('query')); // { q: 'pikachu', tags: ['red','blue'] }
+console.log(req.url); // 최종 URL
+```

--- a/packages/jin-frame/docs/ko/getting-to-start.md
+++ b/packages/jin-frame/docs/ko/getting-to-start.md
@@ -1,0 +1,144 @@
+---
+outline: deep
+---
+
+# Getting To Start
+
+## Installation
+
+npm
+
+```sh
+npm install jin-frame --save
+```
+
+yarn
+
+```sh
+yarn add jin-frame --save
+```
+
+pnpm
+
+```sh
+pnpm add jin-frame --save
+```
+
+## Quick Example
+
+```ts
+import { Get, Param, Query, JinFrame } from 'jin-frame';
+import { randomUUID } from 'node:crypto';
+
+@Get({ 
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/:name',
+})
+export class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+
+  @Query()
+  declare public readonly tid: string;
+}
+
+(async () => {
+  const frame = PokemonFrame.of({ 
+    name: 'pikachu', 
+    tid: randomUUID(),
+  });
+  const reply = await frame.execute();
+  
+  // Show Pikachu Data
+  console.log(reply.data);
+})();
+```
+
+## Customization Examples
+
+Endpoint 별로 각종 설정을 다르게 적용할 수도 있습니다.
+
+```ts
+@Timeout(10_000)  // 10s timeout
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon',
+})
+class PokemonPagingFrame extends JinFrame {
+  @Query()
+  declare public readonly limit: number;
+
+  @Query()
+  declare public readonly offset: number;
+}
+
+@Retry({ max: 3, interval: 1000 }) // 재시도 최대 3번, 1000ms 간격
+@Timeout(2_000)  // 타임아웃 2초
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/:name',
+})
+export class PokemonDetailFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+}
+```
+
+## Why `declare public readonly`?
+
+jin-frame에서 Frame 클래스를 정의할 때는 필드에 보통 다음과 같이 `declare public readonly`를 사용합니다.
+
+```ts
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+
+  @Query()
+  declare public readonly limit?: number;
+}
+```
+
+### 이유
+
+1. **`declare`**
+   - TypeScript에서 `declare` 키워드는 “이 필드는 실제 값이 할당되지 않지만, 타입만 정의된다”는 의미입니다.
+   - 실제 값은 런타임에 `jin-frame`이 생성하여 주입하기 때문에, 클래스 내부에서 직접 초기화할 필요가 없습니다.
+
+2. **`public`**
+   - 접근 제어자를 명시적으로 작성하여 API 필드가 외부에서 접근 가능한 **입력값**임을 분명히 합니다.
+
+3. **`readonly`**
+   - 한번 정의된 값은 변경되지 않아야 하는 **불변 데이터**이므로, `readonly`로 지정하여 안전성을 높입니다.
+   - 예: `@Param() name`은 생성 시점에만 주입되며, 실행 도중 변경되지 않습니다.
+
+## Requirements
+
+### Decorator
+
+1. TypeScript
+1. Decorator
+   - `tsconfig.json` 파일에서 experimentalDecorators, emitDecoratorMetadata option을 활성화 해주세요
+
+```jsonc
+{
+  "extends": "@tsconfig/node20/tsconfig.json",
+  "compilerOptions": {
+    // enable experimentalDecorators, emitDecoratorMetadata for using decorator
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+  },
+}
+```
+
+### Axios version
+
+| jin-frame | axios     |
+| --------- | --------- |
+| 2.x       | <= 0.27.x |
+| 3.x       | >= 1.1.x  |
+| 4.x       | >= 1.4.x  |
+
+### 정리
+
+`declare public readonly`는 **타입 안정성**과 **불변성**을 보장하면서도, 런타임에는 jin-frame이 알아서 값을 채워 넣도록 하기 위한 관용적 패턴입니다. 따라서 jin-frame을 사용할 때는 항상 이 구문을 함께 사용하는 것이 권장됩니다.

--- a/packages/jin-frame/docs/ko/index.md
+++ b/packages/jin-frame/docs/ko/index.md
@@ -1,0 +1,37 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: "jin-frame"
+  text: "Declarative API definition"
+  tagline: A reusable, declarative, type-safe, and extendable HTTP request library.
+  image:
+    src: /assets/jin-frame-brand-icon.png
+    alt: jin-frame
+  actions:
+    - theme: brand
+      text: What is Jin-Frame?
+      link: /what-is-jin-frame
+    - theme: alt
+      text: Getting to Start
+      link: /getting-to-start
+
+features:
+  - title: Declarative API Definition
+    icon: 🎩 
+    details: Define URL, Querystring, Path Parameters, Body, and Headers intuitively using classes and decorators.
+  - title: Type Safety
+    icon: ⛑️ 
+    details: Use TypeScript’s type system to detect type mismatches at compile time.
+  - title: Support for Retry, Hooks, File Upload, Timeout and Mocking
+    icon: 🎢 
+    details: Provides essential features for real-world usage, including Retry, Hooks, File Upload, Timeout and Mocking.
+  - title: Build upon the Axios Ecosystem
+    icon: 🏭 
+    details: 
+  - title: Path Parameter Support
+    icon: 🎪 
+    details: Supports path parameter substitution via URLs, e.g., example.com/:id.
+---
+

--- a/packages/jin-frame/docs/ko/method/authorization.md
+++ b/packages/jin-frame/docs/ko/method/authorization.md
@@ -1,0 +1,41 @@
+---
+outline: deep
+---
+
+# Authorization
+
+이제 `@Header()`를 사용하여 수동으로 `Authorization` 헤더를 정의하지 않고, 더 간편하게 인증을 설정할 수 있는 **`authorization` 옵션**을 사용할 수 있습니다.
+
+## 1. Bearer 토큰 방식
+
+```ts
+@Get({
+  host: 'https://api.example.com',
+  path: '/me',
+  authorization: 'Bearer mytoken123',
+})
+export class MeFrame extends JinFrame {}
+```
+
+자동으로 다음과 같은 요청 헤더가 설정됩니다:
+
+```text
+Authorization: Bearer mytoken123
+```
+
+## 2. Basic 인증 (Axios `auth` 옵션 활용)
+
+```ts
+@Get({
+  host: 'https://api.example.com',
+  path: '/secure',
+  authorization: { username: 'alice', password: 'secret' },
+})
+export class SecureFrame extends JinFrame {}
+```
+
+Axios의 기본 `auth` 필드를 활용하여 다음과 같이 헤더가 설정됩니다:
+
+```text
+Authorization: Basic YWxpY2U6c2VjcmV0
+```

--- a/packages/jin-frame/docs/ko/method/form.md
+++ b/packages/jin-frame/docs/ko/method/form.md
@@ -1,0 +1,71 @@
+---
+outline: deep
+---
+
+# Form
+
+`jin-frame`에서는 **Form 데이터 전송**을 지원합니다. Form 데이터는 크게 두 가지 방식으로 구분됩니다:
+
+- `application/x-www-form-urlencoded`
+- `multipart/form-data`
+
+이를 활용하면 **파일 업로드** 또는 **폼 필드 데이터 전송**을 손쉽게 구현할 수 있습니다.
+
+## application/x-www-form-urlencoded
+
+`application/x-www-form-urlencoded` 방식은 [Axios](https://github.com/axios/axios)에서 제공하는 `transformRequest` 함수를 통해 Form 데이터를 변환합니다. jin-frame에서 `content-type`을 `application/x-www-form-urlencoded`로 지정하면, 기본 제공되는 `transformRequest` 함수를 사용할 수 있습니다. 필요하다면 직접 정의한 `transformRequest` 함수를 생성자 옵션으로 전달하여 동작을 커스터마이즈할 수도 있습니다.
+multipart/form-data
+
+```ts
+@Post({
+  host: 'http://some.api.google.com/jinframe/:passing',
+  contentType: 'application/x-www-form-urlencoded',
+})
+class TestUrlencodedPostFrame extends JinEitherFrame {
+  @Param()
+  declare public readonly passing: string;
+
+  @Body()
+  declare public readonly username: string;
+
+  @Body()
+  declare public readonly password: string;
+}
+```
+
+jin-frame에서 `content-type`을 `application/x-www-form-urlencoded`로 지정하면, 기본 제공되는 `transformRequest` 함수를 사용할 수 있습니다.
+
+- 기본 제공되는 `transformRequest` 함수를 사용할 수 있습니다.
+- 혹은 필요에 따라 직접 정의한 `transformRequest` 함수를 **생성자 옵션으로 전달**할 수도 있습니다.
+
+이를 통해 키-값 쌍 형태의 데이터를 URL 인코딩 방식으로 전송할 수 있습니다.
+
+## multipart/form-data
+
+`multipart/form-data` 방식은 주로 **파일 업로드**나 **복합 데이터 전송**에 사용됩니다. jin-frame은 내부적으로 [form-data](https://github.com/form-data/form-data) 패키지를 활용하여 이 방식을 처리합니다.
+
+```ts
+@Post({
+  host: 'http://some.api.google.com/fileupload-case04',
+  contentType: 'multipart/form-data',
+})
+class TestGetFrame extends JinEitherFrame {
+  @Body()
+  declare public readonly description: string;
+
+  @Body()
+  declare public readonly myFile: JinFile<Buffer>;
+
+  @Body()
+  declare public readonly myFiles: JinFile<Buffer>[];
+}
+```
+
+- `content-type`을 `multipart/form-data`로 설정하면, jin-frame이 `form-data` 패키지를 사용하여 `AxiosRequestConfig.data` 필드 값을 자동으로 생성합니다.
+
+이를 통해 이미지, 문서, 바이너리 파일 등 다양한 데이터를 손쉽게 업로드할 수 있습니다.
+
+## 결론
+
+- 단순한 키-값 데이터 전송에는 `application/x-www-form-urlencoded`를 사용하세요.
+- 파일 업로드나 복합 데이터 전송이 필요하다면 `multipart/form-data`를 선택하세요.

--- a/packages/jin-frame/docs/ko/method/inheritance.md
+++ b/packages/jin-frame/docs/ko/method/inheritance.md
@@ -1,0 +1,157 @@
+---
+outline: deep
+---
+
+# Inheritance
+
+`jin-frame`에서는 상속을 활용하여 공통 기능을 묶거나, 필요한 부분만 확장할 수 있습니다. 이를 통해 API 요청 구조를 간결하게 유지하면서도 다양한 엔드포인트에 유연하게 대응할 수 있습니다.
+
+## Host와 Path 분리
+
+MSA 아키텍처에서는 여러 서버와 통신해야 하는 경우가 많습니다. 이때 서버 주소(`host`)가 변경될 수 있기 때문에, `host`와 `path`를 분리해 관리하는 방식이 유용합니다.
+
+### 부모 클래스 정의
+
+```ts
+import { randomUUID } from 'crypto';
+
+@Timeout(3_000)
+@Get({ host: 'https://pokeapi.co' })
+class PokemonAPI<PASS = unknown, FAIL = unknown> extends JinFrame<PASS, FAIL> {
+  @Query()
+  public declare readonly tid: string;
+
+  protected static override getDefaultValues(): Partial<TFieldsOf<InstanceType<typeof PokemonAPI>>> {
+    return { tid: randomUUID() };
+  }
+}
+```
+
+- 공통 설정: `host`, `timeout`  
+- 자동 필드 생성: `tid`를 UUID로 자동 입력하여 요청 추적에 활용할 수 있습니다.
+
+### 자식 클래스 정의
+
+```ts
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonByNameId extends PokemonAPI<IPokemonData> {
+  @Param()
+  public declare readonly name: string;
+}
+```
+
+- 부모 클래스의 `host`와 `timeout`을 그대로 상속받습니다.  
+- 자식 클래스에서는 `path`와 필요한 `param`만 정의하면 됩니다.
+
+### Builder 패턴 사용
+
+팩토리 메서드 `of`를 직접 사용할 경우, 타입 안정성을 위해 모든 필드를 명시해야 합니다. 이런 경우에는 Builder 패턴을 이용하면 훨씬 편리합니다.
+
+```ts
+// set 방식
+const frame = PokemonByNameId.of(b => b.set('name', 'pikachu'));
+const reply = await frame.execute();
+
+// from 방식
+const frame = PokemonByNameId.of(b => b.from({ name: 'pikachu' }));
+const reply = await frame.execute();
+```
+
+---
+
+## Timeout, Retry 설정 관리
+
+자식 클래스에서 동일한 설정을 재정의하면 부모의 설정을 덮어씁니다. 이를 통해 엔드포인트별로 별도의 타임아웃이나 재시도 정책을 적용할 수 있습니다.
+
+```ts
+@Timeout(5_000)
+@Get({ host: 'https://pokeapi.co' })
+class PokeBaseFrame<P = unknown, F = unknown> extends JinFrame<P, F> {
+}
+
+@Retry({ max: 5, interval: 1000 }) // 재시도 설정 추가
+@Timeout(10_000) // 타임아웃 변경 5,000 > 10,000
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonByNameId extends PokeBaseFrame<IPokemonData> {
+  @Param()
+  public declare readonly name: string;
+}
+
+// 부모 객체 타임아웃인 5000ms 적용
+@Get({ path: '/api/v2/pokemon' })
+class PokemonPaging extends PokeBaseFrame {
+  @Query()
+  declare readonly limit: number;
+
+  @Query()
+  declare readonly offset: number;
+}
+```
+
+- **PokemonByNameId**: 10초 타임아웃, 1초 간격으로 최대 5회 재시도  
+- **PokemonPaging**: 5초 타임아웃, 재시도 없음  
+
+---
+
+## Hook 확장
+
+상속 구조에서는 Hook 또한 확장 가능합니다. 이를 이용하면 공통 로깅이나 예외 처리 로직을 부모 클래스에 배치하고, 필요할 때 자식 클래스에서 보완할 수 있습니다.
+
+### 부모 클래스 Hook 정의
+
+```ts
+@Timeout(3_000)
+@Get({ host: 'https://pokeapi.co' })
+class PokemonAPI<PASS = unknown, FAIL = unknown> extends JinFrame<PASS, FAIL> {
+  @Query()
+  public declare readonly tid: string;
+
+  override async $_postHook(
+    _req: TJinRequestConfig,
+    reply: AxiosResponse<{ message: string }>,
+    _debugInfo: IDebugInfo,
+  ) {
+    if (reply.status >= 400) {
+      // 공통 에러 로깅 처리
+    }
+  }
+}
+```
+
+Hook 함수명에 `$_` prefix가 붙는 이유는 `jin-frame` 내부 규칙상 필드 이름과 충돌을 피하기 위해 Hook과 내부 변수에는 `$_` 접두사가 붙습니다.
+
+### 자식 클래스 Hook 확장
+
+```ts
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonByNameId extends PokemonAPI<IPokemonData> {
+  @Param()
+  public declare readonly name: string;
+
+  override async $_postHook(
+    _req: TJinRequestConfig,
+    reply: AxiosResponse<{ message: string }>,
+    _debugInfo: IDebugInfo,
+  ) {
+    // 부모 Hook 실행
+    await super.$_postHook(_req, reply, _debugInfo);
+
+    // 추가적인 로깅이나 후처리
+    ...
+  }
+}
+```
+
+---
+
+## Conclusion
+
+상속 기능을 활용하면 다음과 같은 장점을 얻을 수 있습니다.
+
+- **공통 관리**: `host`, `timeout`, `hook`, `authorization` 등 반복되는 설정을 부모 클래스에 모아두어 관리 효율을 높일 수 있습니다.  
+- **확장성 확보**: 자식 클래스에서는 필요한 필드(`path`, `param`)와 특수한 설정만 선언하여 손쉽게 확장할 수 있습니다.  
+- **유연한 정책 적용**: 엔드포인트별로 별도 `timeout`, `retry` 정책을 적용할 수 있으며, 공통 Hook에 추가 로직을 덧붙여 세부 제어도 가능합니다.  
+- **타입 안정성 보장**: Builder 패턴을 통해 필드 입력을 안전하게 유도하면서, 실수 가능성을 최소화할 수 있습니다.  
+
+즉, 상속을 적절히 활용하면 공통 로직을 단순하게 유지하면서도, 엔드포인트별 특수성을 유연하게 반영할 수 있습니다.  
+이를 통해 API 요청 구조를 **체계적이고 확장성 있게 관리할 수 있습니다**.

--- a/packages/jin-frame/docs/ko/method/mocking.md
+++ b/packages/jin-frame/docs/ko/method/mocking.md
@@ -1,0 +1,51 @@
+---
+outline: deep
+---
+
+# Mocking
+
+`jin-frame`은 내부적으로 **Axios**를 사용합니다. 따라서 테스트 환경에서는 [axios-mock-adapter](https://github.com/ctimmerm/axios-mock-adapter)를 그대로 활용할 수 있습니다.
+
+이를 통해 실제 서버를 호출하지 않고도 **API 응답을 모킹(Mock)** 하여 개발 및 테스트를 진행할 수 있습니다.
+
+## 간단한 예제
+
+```ts
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+// 기본 axios 인스턴스에 mock 어댑터를 연결
+const mock = new MockAdapter(axios);
+
+// /users 경로로 들어오는 모든 GET 요청을 모킹
+// reply의 인자는 (status, data, headers)
+mock.onGet('/users').reply(200, {
+  users: [{ id: 1, name: 'John Smith' }],
+});
+
+// jin-frame 프레임 실행
+const frame = UserFrame.of({ params: { searchText: 'John' } });
+const reply = await frame.execute();
+
+console.log(reply.data);
+// { users: [{ id: 1, name: 'John Smith' }] }
+```
+
+## 특징
+
+- **실제 서버 호출 불필요**  
+  외부 API 서버가 준비되지 않은 상황에서도 요청/응답을 흉내 낼 수 있습니다.
+
+- **테스트 코드 작성 용이**  
+  특정 경로에 대해 원하는 상태 코드, 데이터, 헤더 등을 직접 지정할 수 있어 단위 테스트 및 통합 테스트 작성이 편리합니다.
+
+- **jin-frame과 자연스럽게 통합**  
+  jin-frame이 Axios를 기반으로 동작하기 때문에, 특별한 설정 없이 `axios-mock-adapter`만 연결하면 그대로 모킹이 가능합니다.
+
+## 활용 시나리오
+
+- 개발 단계에서 **외부 API 서버가 준비되지 않은 경우**
+- QA 환경에서 **특정 케이스를 재현해야 하는 경우**
+- CI/CD 파이프라인에서 **네트워크 의존성을 제거한 테스트 실행**
+
+💡 `axios-mock-adapter`의 자세한 사용법은 [공식 문서](https://github.com/ctimmerm/axios-mock-adapter)를 참고하세요. jin-frame에서는 Axios 인스턴스를 그대로 사용하므로, 문서에 나와 있는 기능들을 동일하게 적용할 수 있습니다.

--- a/packages/jin-frame/docs/ko/method/retry.md
+++ b/packages/jin-frame/docs/ko/method/retry.md
@@ -1,0 +1,52 @@
+---
+outline: deep
+---
+
+# Retry
+
+`jin-frame`에서는 재시도를 단순한 옵션 설정으로 적용할 수 있습니다. 기본적으로는 일정한 간격으로 재시도하지만, 필요하다면 `getInterval` 함수를 정의하여 **재시도 횟수나 전체 소요 시간에 따라 간격을 다르게** 설정할 수도 있습니다.
+
+## interval
+
+가장 단순한 방식으로, **모든 재시도가 동일한 간격**으로 수행됩니다. 예를 들어 `interval: 1000`으로 설정하면 1초마다 동일한 간격으로 재시도를 진행합니다.
+
+## getInterval
+
+여러 클라이언트가 동시에 재시도를 수행하면, 일정한 간격의 재시도가 오히려 서버 부하를 증가시킬 수 있습니다. 이런 경우 `getInterval`을 사용하면 **재시도 횟수, 총 소요 시간** 등을 고려해 보다 유연한 간격을 적용할 수 있습니다.
+
+```ts
+@Retry({
+    max: 5,
+    getInterval: (retry: number, totalDuration: number, eachDuration: number): number => {
+      // 전체 API 호출 시간이 10초를 초과하면 10초마다 재시도
+      if (totalDuration > 10000) {
+        return 10_000;
+      }
+
+      // 그 외에는 (재시도 횟수 × 1000ms) 간격으로 재시도
+      return retry * 1000;
+    },  
+})
+@Get({ 
+  path: '/api/v2/pokemon/:name',
+})
+class PokemonByNameId extends PokemonAPI<IPokemonData> {
+  @Param()
+  public declare readonly name: string;
+}
+```
+
+위 예시는 다음과 같은 특징을 가집니다.
+
+- 최대 5회까지 재시도 수행  
+- 총 소요 시간이 10초를 넘으면 이후에는 10초 간격으로 재시도  
+- 그 외 상황에서는 `1회차 = 1초`, `2회차 = 2초`, … 와 같이 점진적으로 간격을 늘려 재시도  
+
+---
+
+## Conclusion
+
+- 단순히 **고정 간격 재시도**를 원한다면 `interval` 옵션만으로 충분합니다.  
+- 서버 안정성이나 부하 분산을 고려해야 한다면 `getInterval`을 사용해 **동적으로 간격을 제어**하는 것이 좋습니다.  
+
+이러한 기능을 통해 요청의 신뢰성을 확보하면서도, 시스템에 불필요한 부담을 주지 않는 균형 잡힌 재시도 정책을 설계할 수 있습니다.

--- a/packages/jin-frame/docs/ko/usage-method.md
+++ b/packages/jin-frame/docs/ko/usage-method.md
@@ -1,0 +1,155 @@
+---
+outline: deep
+---
+
+# HTTP Method 데코레이터
+
+`jin-frame`은 HTTP 요청을 **클래스 단위**로 선언하기 위해 메서드별 데코레이터를 제공합니다.
+
+지원 데코레이터: `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@Link`, `@Unlink`, `@Purge`, `@Search`
+
+> 핵심: **엔드포인트(호스트/경로/타임아웃/재시도/컨텐츠 타입 등)** 을 데코레이터 옵션으로 선언하고, **경로/쿼리/헤더/바디**는 `@Param`, `@Query`, `@Header`, `@Body`(또는 `@ObjectBody`)로 지정합니다.
+
+## Quick Examples
+
+### GET (쿼리 + 경로)
+
+```ts
+@Timeout(10_000) // 10s timeout
+@Get({
+  host: 'https://api.example.com',
+  path: '/orgs/:orgId/users',
+  authorization: process.env.YOUR_AUTH_TOKEN
+})
+export class ListUsersFrame extends JinFrame {
+  @Param() 
+  declare readonly orgId: string;
+
+  @Query() 
+  declare readonly page?: number;
+}
+
+// Execute
+const frame = ListUsersFrame.of({ orgId: 'acme', page: 1 });
+const reply = await frame.execute();
+```
+
+### POST (JSON 바디)
+
+```ts
+@Timeout(5_000) // 5s timeout
+@Post({
+  host: 'https://api.example.com',
+  path: '/users',
+  // 기본(contentType 미설정 시) application/json 로 전송
+})
+export class CreateUserFrame extends JinFrame {
+  @Body('name') declare readonly name: string;
+  @Body('email') declare readonly email: string;
+}
+
+// Execute
+const frame = CreateUserFrame.of({ name: 'Alice', email: 'alice@acme.com' });
+const res = await frame.execute();
+```
+
+### POST (multipart/form-data, 파일 업로드)
+
+```ts
+@Post({
+  host: 'https://upload.example.com',
+  path: '/files',
+  contentType: 'multipart/form-data',
+})
+export class UploadFrame extends JinFrame {
+  @Body() 
+  declare readonly title: string;
+  
+  @Body() 
+  declare readonly attachments: JinFile[]; // JinFile 또는 JinFile[] 지원
+}
+
+// Execute
+const file = new JinFile(new File(['hello'], 'hello.txt'), 'hello.txt');
+const frame = UploadFrame.of({ title: 'greeting', attachments: [file] });
+await frame.execute();
+```
+
+### PUT / PATCH / DELETE
+
+```ts
+@Patch({ 
+  host: 'https://api.example.com', 
+  path: '/users/:id',
+})
+export class UpdateUserFrame extends JinFrame {
+  @Param() 
+  declare readonly id: string;
+  
+  @Body() 
+  declare readonly name?: string;
+}
+
+@Delete({
+  host: 'https://api.example.com',
+  path: '/users/:id',
+})
+export class DeleteUserFrame extends JinFrame {
+  @Param() 
+  declare readonly id: string;
+}
+```
+
+## 데코레이터 옵션
+
+모든 메서드 데코레이터(`@Get`, `@Post`, …)는 공통 옵션을 받습니다.
+
+| 옵션               | 타입                                                                                 | 설명                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `host`             | `string`                                                                             | 베이스 URL(프로토콜 포함). 예: `https://api.example.com`                        |
+| `path`             | `string`                                                                             | 경로. `:id` 처럼 **Path Param** 플레이스홀더 지원                               |
+| `timeout`          | `number`                                                                             | 요청 타임아웃(ms). 미설정 시 라이브러리 기본값 사용                             |
+| `retry`            | `{ max: number; interval?: number }` \*                                              | 재시도 설정. `max`는 최대 시도 횟수, `interval`은 시도 간 대기(ms)              |
+| `method`           | `string`                                                                             | 내부적으로 설정되지만, 커스텀 메서드가 필요하면 명시 가능                       |
+| `contentType`      | `'application/json' \| 'multipart/form-data' \| 'application/x-www-form-urlencoded'` | 전송 포맷 지정                                                                  |
+| `customBody`       | `unknown`                                                                            | 데코레이터/필드 바디 대신 **커스텀 바디**를 직접 지정                           |
+| `transformRequest` | `AxiosRequestTransformer \| AxiosRequestTransformer[]`                               | axios 변환기. `x-www-form-urlencoded` 기본 변환기가 자동 주입됨(옵션 미설정 시) |
+| `validateStatus`   | `(status: number) => boolean`                                                        | axios 상태 검증기. 재시도 조건과 함께 사용 가능                                 |
+| `userAgent`        | `string`                                                                             | User-Agent 지정. 브라우저 보안 제약으로 무시될 수 있음(옵션으로는 설정 가능)    |
+| `authorization`    | `string` or `{ usename: string; password: string }`                                  | Header Authorization 필드 값을 설정하거나 Basic Auth 설정을 설정                |
+
+## Body 전송 규칙 & Content-Type
+
+- `application/json` (기본): 바디 객체를 JSON으로 전송합니다.
+- `multipart/form-data`: **POST 요청에서만** 내부 FormData 생성 로직이 동작합니다.
+  - `JinFile`/`JinFile[]`은 파일 파트로 추가됩니다.
+  - 문자열/숫자/불리언/객체는 적절히 문자열화하여 파트로 추가됩니다.
+- `application/x-www-form-urlencoded`: 라이브러리가 기본 `transformRequest`를 주입해 `key=value&…`로 변환합니다.
+  - 사용자 정의 `transformRequest`가 있으면 그 값을 우선합니다.
+
+> 참고: 코드상 `multipart/form-data` 자동 변환은 **POST**에 한해 동작합니다. `PUT/PATCH/DELETE`에서 멀티파트가 필요하면 `customBody` 또는 `transformRequest`를 활용하세요.
+
+## 메서드별 관례(Idempotency)
+
+- `GET`: 조회. 바디 없이 **쿼리/헤더/경로**로 전달.
+- `POST`: 생성/액션. **바디 전송** 주로 사용.
+- `PUT`/`PATCH`: 갱신. 바디 전송 가능.
+- `DELETE`: 삭제. 필요 시 바디/쿼리 사용(서버 규약에 따름).
+
+라이브러리는 axios에 `data`를 전달하므로, 서버가 허용한다면 `PUT/PATCH/DELETE`에도 바디 전송이 가능합니다.
+
+## 디버깅 팁
+
+```ts
+const frame = SomeFrame.of(/* ... */);
+const req = frame.request();
+
+console.log(frame.getOption('method')); // 설정된 HTTP 메서드
+console.log(frame.getData('param')); // 최종 Path Params
+console.log(frame.getData('query')); // 최종 Query
+console.log(frame.getData('header')); // 최종 Header (직렬화 전)
+console.log(req); // axios 최종 요청 설정
+```
+
+> 요청 중간 상태를 확인하고 싶으면 `.request()`로 axios 설정 객체를 받아보세요.  
+> `.execute()`는 실제 네트워크 호출을 수행합니다.

--- a/packages/jin-frame/docs/ko/what-is-jin-frame.md
+++ b/packages/jin-frame/docs/ko/what-is-jin-frame.md
@@ -1,0 +1,96 @@
+# jin-frame이란?
+
+<!-- markdownlint-disable MD033 -->
+<p align="center">
+  <img src="../assets/jin-frame-brand.png" alt="brand" width="300"/>
+</p>
+<!-- markdownlint-enable MD033 -->
+
+**HTTP Request**를 **TypeScript Class**로 정의할 수 있도록 돕는 라이브러리입니다. 단순히 HTTP 요청을 정의하는 것에 그치지 않고, 실무 환경에서 자주 필요한 다양한 기능을 제공합니다. 예를 들어 Hook 정의, timeout 설정, 재시도 횟수 지정 등을 엔드포인트별로 다르게 설정할 수 있으며, 이 모든 것을 TypeScript Class를 기반으로 선언적으로 정의할 수 있습니다. 궁극적으로는 **API를 효율적으로 관리**하는 것이 목표입니다.
+
+## 왜 jin-frame인가?
+
+- 🎩 **선언적인 API 정의**  
+  데코레이터와 클래스를 활용해 URL, Querystring, Path Param, Body, Header를 명확하고 직관적으로 정의할 수 있습니다.
+
+- ⛑️ **타입 안정성**  
+  TypeScript의 타입 시스템을 적극 활용하여, 타입 불일치는 컴파일 단계에서 바로 잡아낼 수 있습니다.
+
+- 🎢 **Production-Ready 기능**  
+  290개의 테스트 케이스로 신뢰성을 확보하였으며, MSA 환경에서 요구되는 retry, hook, file upload, mocking 기능을 지원합니다.
+
+- 🏭 **Axios 생태계 활용**  
+  Axios 위에 구축되어 있어 안정적인 생태계를 활용하면서 기능을 확장할 수 있습니다.
+
+- 🎪 **Path Parameter 지원**  
+  `example.com/:id`와 같은 path parameter를 타입 안정성을 보장하며 치환할 수 있습니다.
+
+## 제공 기능
+
+- **Retry 설정**  
+  최대 횟수, 고정 간격, 점진적 간격 증가 등 다양한 재시도 정책을 구성할 수 있습니다.
+
+- **Hook 지원**  
+  요청 전/후, 재시도 시점에 Hook을 정의할 수 있습니다. 상속을 통해 전역 공통 Hook을 적용하거나 엔드포인트 단위로 별도로 적용할 수도 있습니다.
+
+- **엔드포인트별 Timeout**  
+  마이크로서비스 환경에서 엔드포인트마다 다른 timeout 값을 적용할 수 있습니다.
+
+- **파일 업로드**  
+  Axios 기반의 파일 업로드를 동일한 클래스 정의 방식으로 처리할 수 있습니다.
+
+- **Mocking 지원**  
+  테스트나 개발 환경에서 API 응답을 손쉽게 모킹할 수 있습니다.
+
+- **확장성**  
+  Frame 클래스는 상속이 가능해, 공통 로직을 확장하거나 재사용 가능한 구성 요소로 만들 수 있습니다.
+
+## 사용 예시
+
+기존 Axios를 직접 사용할 때와 jin-frame을 사용할 때의 비교 예시는 다음과 같습니다.
+
+| Direct usage                           | Jin-Frame                                     |
+| -------------------------------------- | --------------------------------------------- |
+| ![axios](../assets/axios-usage.png)    | ![jin-frame](../assets/jinframe-usage.png)    |
+| [axios svg](../assets/axios-usage.svg) | [jin-frame svg](../assets/jinframe-usage.svg) |
+
+코드 양 자체는 비슷하지만, jin-frame은 **각 변수가 Querystring, Header, Body, Path Param 중 어디에 들어가는지 명확하게 보인다**는 점이 다릅니다. 또한 `of`라는 정적 팩토리 메서드를 통해 타입 안정성을 유지하면서 Request를 생성하고 실행할 수 있습니다.
+
+추가로, 엔드포인트별로 timeout과 재시도 횟수를 다르게 설정할 수 있습니다. 이는 MSA 환경에서 여러 API 서버와 연결할 때 매우 자주 요구되는 패턴이며, jin-frame에서는 선언적으로 쉽게 설정할 수 있습니다.
+
+```ts
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon',
+  timeout: 10_000, // 10초
+})
+class PokemonPagingFrame extends JinFrame {
+  @Query()
+  declare readonly limit: number;
+
+  @Query()
+  declare readonly offset: number;
+}
+
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/:name',
+  timeout: 2_000, // 2초
+  retry: { max: 3, inteval: 1000 }, // 1초 간격으로 3회 재시도
+})
+export class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+
+  @Query()
+  declare public readonly tid: string;
+}
+```
+
+이러한 설정은 상속을 통해 재사용 가능하므로, 다양한 상황에 맞게 확장할 수 있습니다.
+
+## 결론
+
+jin-frame은 단순히 Axios를 감싸는 유틸리티가 아니라, **타입 안정성과 선언적 코드 스타일**, 그리고 **MSA 환경에 필요한 기능**을 결합한 HTTP Request 관리 라이브러리입니다. 이를 통해 개발자는 API 요청을 더욱 명확하고 체계적으로 정의할 수 있으며, 유지보수와 확장성 측면에서도 높은 생산성을 기대할 수 있습니다.
+
+또한 이렇게 정의한 클래스를 하나의 패키지로 분리해 두면, 공통 API 요청 로직을 여러 프로젝트에서 재사용할 수도 있습니다. 즉, 팀 단위 혹은 조직 전체에서 동일한 규격의 API 호출 방식을 공유할 수 있어, **일관성과 재사용성**을 동시에 확보할 수 있습니다.

--- a/packages/jin-frame/docs/method/authorization.md
+++ b/packages/jin-frame/docs/method/authorization.md
@@ -1,0 +1,42 @@
+---
+outline: deep
+---
+
+# Authorization
+
+Instead of manually defining an `Authorization` header using `@Header()`,  
+you can now use the **`authorization` option** to configure authentication more conveniently.
+
+## 1. Bearer Token
+
+```ts
+@Get({
+  host: 'https://api.example.com',
+  path: '/me',
+  authorization: 'Bearer mytoken123',
+})
+export class MeFrame extends JinFrame {}
+```
+
+This automatically sets the request header:
+
+```text
+Authorization: Bearer mytoken123
+```
+
+## 2. Basic Auth (Axios `auth` option)
+
+```ts
+@Get({
+  host: 'https://api.example.com',
+  path: '/secure',
+  authorization: { username: 'alice', password: 'secret' },
+})
+export class SecureFrame extends JinFrame {}
+```
+
+This uses the native Axios `auth` field:
+
+```text
+Authorization: Basic YWxpY2U6c2VjcmV0
+```

--- a/packages/jin-frame/docs/method/form.md
+++ b/packages/jin-frame/docs/method/form.md
@@ -1,0 +1,66 @@
+---
+outline: deep
+---
+
+# Form
+
+**`jin-frame`** supports **form data submission**, which can be handled in two main ways:
+
+- `application/x-www-form-urlencoded`
+- `multipart/form-data`
+
+These formats make it easy to handle **file uploads** or **form field submissions**.
+
+## application/x-www-form-urlencoded
+
+The `application/x-www-form-urlencoded` format uses Axios’s built-in [`transformRequest`](https://github.com/axios/axios) function to convert form data. When you set the `content-type` to `application/x-www-form-urlencoded` in jin-frame, you can use the default `transformRequest` function. If needed, you can also pass your own `transformRequest` function as a constructor option to customize behavior.
+
+```ts
+@Post({
+  host: 'http://some.api.google.com/jinframe/:passing',
+  contentType: 'application/x-www-form-urlencoded',
+})
+class TestUrlencodedPostFrame extends JinEitherFrame {
+  @Param()
+  declare public readonly passing: string;
+
+  @Body()
+  declare public readonly username: string;
+
+  @Body()
+  declare public readonly password: string;
+}
+```
+
+By setting the `content-type` to `application/x-www-form-urlencoded`, jin-frame will automatically apply its default `transformRequest` function. Alternatively, you can define and provide a custom `transformRequest` function through constructor options.  
+This allows you to transmit key-value data in the standard URL-encoded format.
+
+## multipart/form-data
+
+The `multipart/form-data` format is mainly used for **file uploads** or **complex data submissions**. Internally, jin-frame uses the [form-data](https://github.com/form-data/form-data) package to process this format.
+
+```ts
+@Post({
+  host: 'http://some.api.google.com/fileupload-case04',
+  contentType: 'multipart/form-data',
+})
+class TestGetFrame extends JinEitherFrame {
+  @Body()
+  declare public readonly description: string;
+
+  @Body()
+  declare public readonly myFile: JinFile<Buffer>;
+
+  @Body()
+  declare public readonly myFiles: JinFile<Buffer>[];
+}
+```
+
+- When `content-type` is set to `multipart/form-data`, jin-frame uses the `form-data` package to automatically generate the `AxiosRequestConfig.data` field value.
+
+This makes it simple to upload a variety of data types, including images, documents, and binary files.
+
+## Summary
+
+- Use `application/x-www-form-urlencoded` for simple key-value data submissions.
+- Use `multipart/form-data` when uploading files or sending complex structured data.

--- a/packages/jin-frame/docs/method/inheritance.md
+++ b/packages/jin-frame/docs/method/inheritance.md
@@ -1,0 +1,156 @@
+---
+outline: deep
+---
+
+# Inheritance
+
+In **`jin-frame`**, inheritance can be used to group common functionality or extend only what is needed. This helps keep API request structures simple while allowing flexible handling of diverse endpoints.
+
+## Separating Host and Path
+
+In an MSA architecture, you often communicate with multiple servers. Since the server address (`host`) can change, it is useful to separate `host` and `path` for easier management.
+
+### Parent Class Definition
+
+```ts
+import { randomUUID } from 'crypto';
+
+@Timeout(3_000)
+@Get({ host: 'https://pokeapi.co' })
+class PokemonAPI<PASS = unknown, FAIL = unknown> extends JinFrame<PASS, FAIL> {
+  @Query()
+  declare public readonly tid: string;
+
+  protected static override getDefaultValues(): Partial<TFieldsOf<InstanceType<typeof PokemonAPI>>> {
+    return { tid: randomUUID() };
+  }
+}
+```
+
+- **Shared settings:** `host`, `timeout`
+- **Automatic field injection:** `tid` is automatically filled with a UUID for request tracking.
+
+### Child Class Definition
+
+```ts
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonByNameId extends PokemonAPI<IPokemonData> {
+  @Param()
+  declare public readonly name: string;
+}
+```
+
+- Inherits the parent class’s `host` and `timeout`.
+- The child class only needs to define the `path` and the required `param`.
+
+### Using the Builder Pattern
+
+When using the `of` factory method directly, you need to specify all fields for type safety. In this case, the Builder pattern makes it much easier.
+
+```ts
+// set style
+const frame = PokemonByNameId.of((b) => b.set('name', 'pikachu'));
+const reply = await frame.execute();
+
+// from style
+const frame = PokemonByNameId.of((b) => b.from({ name: 'pikachu' }));
+const reply = await frame.execute();
+```
+
+---
+
+## Managing Timeout and Retry Settings
+
+If the child class redefines the same configuration, it overrides the parent’s setting. This allows you to apply different timeouts or retry policies per endpoint.
+
+```ts
+@Timeout(5_000)
+@Get({ host: 'https://pokeapi.co' })
+class PokeBaseFrame<P = unknown, F = unknown> extends JinFrame<P, F> {
+}
+
+@Retry({ max: 5, interval: 1000 })
+@Timeout(10_000) // timeout overwrite 5,000 > 10,000
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonByNameId extends PokeBaseFrame {
+  @Param()
+  declare public readonly name: string;
+}
+
+// timeout use parent configuration: 5,000
+@Get({ path: '/api/v2/pokemon' })
+class PokemonPaging extends PokeBaseFrame {
+  @Query()
+  declare readonly limit: number;
+
+  @Query()
+  declare readonly offset: number;
+}
+```
+
+- **PokemonByNameId**: 10s timeout, retry up to 5 times with 1s interval
+- **PokemonPaging**: 5s timeout, no retry
+
+---
+
+## Hook Extension
+
+Hooks can also be extended in an inheritance structure. This allows you to place common logging or exception handling logic in the parent class and supplement it in the child class as needed.
+
+### Parent Class Hook
+
+```ts
+@Timeout(3_000)
+@Get({ host: 'https://pokeapi.co' })
+class PokemonAPI<PASS = unknown, FAIL = unknown> extends JinFrame<PASS, FAIL> {
+  @Query()
+  declare public readonly tid: string;
+
+  override async $_postHook(
+    _req: TJinRequestConfig,
+    reply: AxiosResponse<{ message: string }>,
+    _debugInfo: IDebugInfo,
+  ) {
+    if (reply.status >= 400) {
+      // Common error logging
+    }
+  }
+}
+```
+
+The reason hook methods use the `$_` prefix is that `jin-frame` reserves this naming to avoid conflicts with field names.
+
+### Extending Hook in Child Class
+
+```ts
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonByNameId extends PokemonAPI<IPokemonData> {
+  @Param()
+  public declare readonly name: string;
+
+  override async $_postHook(
+    _req: TJinRequestConfig,
+    reply: AxiosResponse<{ message: string }>,
+    _debugInfo: IDebugInfo,
+  ) {
+    // Execute parent hook
+    await super.$_postHook(_req, reply, _debugInfo);
+
+    // Additional logging or post-processing
+    ...
+  }
+}
+```
+
+---
+
+## Summary
+
+Using inheritance provides several advantages:
+
+- **Centralized management:** Shared settings such as `host`, `timeout`, `hook`, and `authorization` can be managed in the parent class, improving efficiency.
+- **Extensibility:** Child classes only need to declare the `path`, `param`, or special settings, making extension straightforward.
+- **Flexible policy application:** Apply different `timeout` and `retry` policies per endpoint, and extend common hooks with additional logic when needed.
+- **Type safety:** The Builder pattern ensures safe field initialization, minimizing errors.
+
+In short, inheritance helps you keep shared logic simple while flexibly adapting to endpoint-specific needs, making API request structures **systematic and scalable**.

--- a/packages/jin-frame/docs/method/mocking.md
+++ b/packages/jin-frame/docs/method/mocking.md
@@ -1,0 +1,52 @@
+---
+outline: deep
+---
+
+# Mocking
+
+**`jin-frame`** internally uses **Axios**. Therefore, in test environments, you can directly use [axios-mock-adapter](https://github.com/ctimmerm/axios-mock-adapter).
+
+This allows you to **mock API responses** without calling a real server, making development and testing much easier.
+
+## Simple Example
+
+```ts
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+// Attach the mock adapter to the default axios instance
+const mock = new MockAdapter(axios);
+
+// Mock all GET requests to /users
+// Arguments for reply are (status, data, headers)
+mock.onGet('/users').reply(200, {
+  users: [{ id: 1, name: 'John Smith' }],
+});
+
+// Execute a jin-frame class
+const frame = UserFrame.of({ params: { searchText: 'John' } });
+const reply = await frame.execute();
+
+console.log(reply.data);
+// { users: [{ id: 1, name: 'John Smith' }] }
+```
+
+## Key Features
+
+- **No real server required**  
+  You can simulate request/response cycles even when the external API server is not available.
+
+- **Easy test code authoring**  
+  You can specify status codes, response data, and headers for given routes, making it simple to write unit and integration tests.
+
+- **Seamless jin-frame integration**  
+  Since jin-frame is built on top of Axios, you only need to attach `axios-mock-adapter`—no additional setup required.
+
+## Use Cases
+
+- During development, when an **external API server is not yet available**  
+- In QA environments, when you need to **reproduce specific scenarios**  
+- In CI/CD pipelines, when running tests that **remove network dependencies**
+
+💡 For more details, refer to the [official axios-mock-adapter documentation](https://github.com/ctimmerm/axios-mock-adapter).  
+Since jin-frame uses Axios directly, all the features described in that documentation can be applied without modification.

--- a/packages/jin-frame/docs/method/retry.md
+++ b/packages/jin-frame/docs/method/retry.md
@@ -1,0 +1,50 @@
+---
+outline: deep
+---
+
+# Retry
+
+In **`jin-frame`**, retries can be applied with a simple option configuration. By default, retries occur at fixed intervals, but you can define a `getInterval` function to **dynamically adjust intervals based on retry count or total elapsed time**.
+
+## interval
+
+The simplest approach is to retry at a **constant interval**. For example, setting `interval: 1000` will retry every second at a fixed interval.
+
+## getInterval
+
+When multiple clients retry at the same fixed interval, it may actually increase server load. In such cases, using `getInterval` allows you to apply more flexible retry spacing based on **retry count and total duration**.
+
+```ts
+@Retry({
+    max: 5,
+    getInterval: (retry: number, totalDuration: number, eachDuration: number): number => {
+      // If total API call time exceeds 10 seconds, retry every 10 seconds
+      if (totalDuration > 10000) {
+        return 10_000;
+      }
+
+      // Otherwise, retry with (retry count × 1000ms) spacing
+      return retry * 1000;
+    },  
+})
+@Get({ path: '/api/v2/pokemon/:name' })
+class PokemonByNameId extends PokemonAPI<IPokemonData> {
+  @Param()
+  declare public readonly name: string;
+}
+```
+
+This example has the following characteristics:
+
+- Retries up to 5 times
+- If total elapsed time exceeds 10 seconds, subsequent retries occur every 10 seconds
+- Otherwise, retries occur progressively: `1st = 1s`, `2nd = 2s`, … increasing intervals
+
+---
+
+## Conclusion
+
+- If you only need **fixed interval retries**, the `interval` option is sufficient.
+- If you need to consider server stability or load balancing, use `getInterval` to **dynamically control intervals**.
+
+These features let you design a retry policy that ensures request reliability while avoiding unnecessary stress on the system.

--- a/packages/jin-frame/docs/usage-method.md
+++ b/packages/jin-frame/docs/usage-method.md
@@ -1,0 +1,158 @@
+---
+outline: deep
+---
+
+# HTTP Method Decorators
+
+**`jin-frame`** provides method decorators for declaring HTTP requests **at the class level**.
+
+Supported decorators: `@Get`, `@Post`, `@Put`, `@Patch`, `@Delete`, `@Link`, `@Unlink`, `@Purge`, `@Search`
+
+> Key point: Declare **endpoint settings (host, path, timeout, retry, content type, etc.)** as decorator options, and specify **path/query/header/body** fields using `@Param`, `@Query`, `@Header`, `@Body` (or `@ObjectBody`).
+
+## Quick Examples
+
+### GET (Query + Path)
+
+```ts
+@Timeout(10_000) // 10s timeout
+@Get({
+  host: 'https://api.example.com',
+  path: '/orgs/:orgId/users',
+  authorization: process.env.YOUR_AUTH_TOKEN
+})
+export class ListUsersFrame extends JinFrame {
+  @Param()
+  declare readonly orgId: string;
+
+  @Query()
+  declare readonly page?: number;
+}
+
+// Execute
+const frame = ListUsersFrame.of({ orgId: 'acme', page: 1 });
+const reply = await frame.execute();
+```
+
+### POST (JSON Body)
+
+```ts
+@Timeout(5_000) // 5s timeout
+@Post({
+  host: 'https://api.example.com',
+  path: '/users',
+  // Defaults to application/json when contentType is not specified
+})
+export class CreateUserFrame extends JinFrame {
+  @Body()
+  declare readonly name: string;
+
+  @Body()
+  declare readonly email: string;
+}
+
+// Execute
+const frame = CreateUserFrame.of({ name: 'Alice', email: 'alice@acme.com' });
+const res = await frame.execute();
+```
+
+### POST (multipart/form-data, File Upload)
+
+```ts
+@Post({
+  host: 'https://upload.example.com',
+  path: '/files',
+  contentType: 'multipart/form-data',
+})
+export class UploadFrame extends JinFrame {
+  @Body()
+  declare readonly title: string;
+
+  @Body() 
+  declare readonly attachments: JinFile[]; // Supports JinFile or JinFile[]
+}
+
+// Execute
+const file = new JinFile(new File(['hello'], 'hello.txt'), 'hello.txt');
+const frame = UploadFrame.of({ title: 'greeting', attachments: [file] });
+await frame.execute();
+```
+
+### PUT / PATCH / DELETE
+
+```ts
+@Patch({ 
+  host: 'https://api.example.com',
+  path: '/users/:id',
+})
+export class UpdateUserFrame extends JinFrame {
+  @Param() 
+  declare readonly id: string;
+
+  @Body() 
+  declare readonly name?: string;
+}
+
+@Delete({
+  host: 'https://api.example.com',
+  path: '/users/:id',
+})
+export class DeleteUserFrame extends JinFrame {
+  @Param() 
+  declare readonly id: string;
+}
+```
+
+## Decorator Options
+
+All method decorators (`@Get`, `@Post`, …) accept common options:
+
+| Option             | Type                                                                                 | Description                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `host`             | `string`                                                                             | Base URL (including protocol). Example: `https://api.example.com`           |
+| `path`             | `string`                                                                             | Path. Supports **Path Param** placeholders like `:id`                       |
+| `timeout`          | `number`                                                                             | Request timeout (ms). Uses library default if not set                       |
+| `retry`            | `{ max: number; interval?: number }` \*                                              | Retry policy. `max` is max attempts, `interval` is delay between retries(ms)|
+| `method`           | `string`                                                                             | Normally set internally, but can be overridden for custom methods           |
+| `contentType`      | `'application/json' \| 'multipart/form-data' \| 'application/x-www-form-urlencoded'` | Specifies the request content type                                          |
+| `customBody`       | `unknown`                                                                            | Provide a **custom body** instead of using decorated fields                 |
+| `transformRequest` | `AxiosRequestTransformer \| AxiosRequestTransformer[]`                               | Axios request transformer. Defaults to `x-www-form-urlencoded` transformer  |
+| `validateStatus`   | `(status: number) => boolean`                                                        | Axios status validator. Works with retry conditions                         |
+| `userAgent`        | `string`                                                                             | Sets User-Agent. May be ignored due to browser security restrictions        |
+| `authorization`    | `string` or `{ username: string; password: string }`                                 | Configure `Authorization` header directly or with Basic Auth                |
+
+## Body Transmission Rules & Content-Type
+
+- **`application/json` (default):** Sends body objects as JSON.  
+- **`multipart/form-data`:** Internal FormData handling works **only for POST requests**.  
+  - `JinFile` / `JinFile[]` are added as file parts.  
+  - Strings/numbers/booleans/objects are stringified and added as form parts.  
+- **`application/x-www-form-urlencoded`:** The library injects a default `transformRequest` to encode as `key=value&…`.  
+  - If a custom `transformRequest` is provided, that takes precedence.
+
+> Note: `multipart/form-data` auto-conversion only works for **POST**. For `PUT/PATCH/DELETE` with multipart, use `customBody` or `transformRequest`.
+
+## Method Semantics (Idempotency)
+
+- `GET`: Read-only. Pass data via **query/header/path** (no body).  
+- `POST`: Creation/action. Commonly includes a **body**.  
+- `PUT` / `PATCH`: Update. Can include body.  
+- `DELETE`: Deletion. Can include body/query depending on server rules.  
+
+Since the library passes `data` to Axios, bodies are possible for `PUT/PATCH/DELETE` if the server supports them.
+
+## Debugging Tip
+
+```ts
+const frame = SomeFrame.of(/* ... */);
+const req = frame.request();
+
+console.log(frame.getOption('method')); // Configured HTTP method
+console.log(frame.getData('param')); // Final Path Params
+console.log(frame.getData('query')); // Final Query Params
+console.log(frame.getData('header')); // Final Headers (before serialization)
+console.log(req); // Final Axios request config
+```
+
+> If you want to inspect the request before sending, use `.request()` to get the Axios config object.  
+> `.execute()` actually performs the network call.

--- a/packages/jin-frame/docs/what-is-jin-frame.md
+++ b/packages/jin-frame/docs/what-is-jin-frame.md
@@ -1,0 +1,101 @@
+# What is jin-frame?
+
+<!-- markdownlint-disable MD033 -->
+<p align="center">
+  <img src="../assets/jin-frame-brand.png" alt="brand" width="300"/>
+</p>
+<!-- markdownlint-enable MD033 -->
+
+**`jin-frame`** is a library that allows you to define **HTTP Requests** as **TypeScript Classes**.
+
+It goes beyond simply defining requests by providing a variety of features frequently required in real-world applications. For example, you can configure hooks, set timeouts, and specify retry counts differently per endpoint. All of these configurations are expressed declaratively through TypeScript classes. The ultimate goal is to help you **manage APIs more effectively**.
+
+## Why jin-frame?
+
+- 🎩 **Declarative API Definition**  
+  Define URL, Querystring, Path Param, Body, and Header clearly and intuitively using decorators and classes.
+
+- ⛑️ **Type Safety**  
+  Leverages TypeScript’s type system to catch mismatches at compile time.
+
+- 🎢 **Production-Ready Features**  
+  Backed by 290 test cases ensuring reliability, and equipped with features essential for MSA environments such as retry, hooks, file upload, and mocking.
+
+- 🏭 **Axios Ecosystem**  
+  Built on top of Axios, allowing you to take advantage of its stable ecosystem while extending its functionality.
+
+- 🎪 **Path Parameter Support**  
+  Safely replace path parameters like `example.com/:id` with strong typing guarantees.
+
+## Features
+
+- **Retry Configuration**  
+  Flexible retry policies such as maximum attempts, fixed intervals, or exponential backoff.
+
+- **Hook Support**  
+  Define hooks before and after requests, or at retry timing. Hooks can be applied globally through inheritance or customized per endpoint.
+
+- **Timeouts per Endpoint**  
+  Apply different timeout values for each endpoint, useful in microservices environments.
+
+- **File Upload**  
+  Handle file uploads seamlessly with Axios under the same class-based request definitions.
+
+- **Mocking Support**  
+  Easily mock API responses for testing and development environments.
+
+- **Extensibility**  
+  Frame classes can be inherited, making it easy to extend configurations and build reusable components.
+
+## Usage Example
+
+Here’s a comparison between using Axios directly and using jin-frame:
+
+| Direct usage                           | Jin-Frame                                     |
+| -------------------------------------- | --------------------------------------------- |
+| ![axios](../assets/axios-usage.png)    | ![jin-frame](../assets/jinframe-usage.png)    |
+| [axios svg](../assets/axios-usage.svg) | [jin-frame svg](../assets/jinframe-usage.svg) |
+
+The amount of code is similar, but jin-frame makes it **clear which variables belong to Querystring, Header, Body, or Path Param**.  
+Also, by using the static factory method `of`, you can create and execute requests in a type-safe way.
+
+Additionally, you can configure timeouts and retry counts differently per endpoint. This is a common requirement when working with multiple API servers in an MSA environment, and jin-frame allows you to configure this declaratively.
+
+```ts
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon',
+  timeout: 10_000, // 10 seconds
+})
+class PokemonPagingFrame extends JinFrame {
+  @Query()
+  declare readonly limit: number;
+
+  @Query()
+  declare readonly offset: number;
+}
+
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/:name',
+  timeout: 2_000, // 2 seconds
+  retry: { max: 3, inteval: 1000 }, // retry up to 3 times, 1s interval
+})
+export class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+
+  @Query()
+  declare public readonly tid: string;
+}
+```
+
+These configurations can also be reused through inheritance, making it easy to extend for different use cases.
+
+## Conclusion
+
+**`jin-frame`** is not just a utility wrapper around Axios. It is a **type-safe, declarative, and extensible HTTP Request management library** designed to meet the needs of MSA environments.  
+
+With jin-frame, developers can define API requests more clearly and systematically, gaining productivity in both maintenance and scalability.
+
+Moreover, classes defined this way can be separated into a standalone package, allowing the **reuse of common API request logic across multiple projects**. This enables teams or organizations to share a consistent API calling pattern, ensuring both **consistency and reusability**.


### PR DESCRIPTION
- Introduced new documentation files covering installation, usage methods, and field decorators for jin-frame.
- Added detailed sections on HTTP method decorators, body handling, query parameters, headers, and formatters.
- Included examples and debugging tips to enhance user understanding and facilitate easier implementation.
- Translated documentation into Korean to support a wider audience.