### PR TITLE
docs(validation): update validator registration comments for clarity

### DIFF
--- a/packages/jin-frame/docs/ko/method/validation.md
+++ b/packages/jin-frame/docs/ko/method/validation.md
@@ -88,10 +88,10 @@ class UserValidator extends Validator<
 ### JinFrame과 함께 사용
 
 ```typescript
+@Validator(new UserValidator()) // 검증기 등록
 @Post({
   host: 'https://api.example.com',
   path: '/users',
-  validator: new UserValidator(), // 검증기 등록
 })
 class CreateUserFrame extends JinFrame<UserData> {
   @Body()
@@ -192,10 +192,10 @@ class ProductValidator extends Validator<
 }
 
 // 2. Frame에 적용
+@Validator(new ProductValidator()) // 검증기 등록
 @Get({
   host: 'https://api.shop.com',
   path: '/products/:id',
-  validator: new ProductValidator(),
 })
 class GetProductFrame extends JinFrame<Product> {
   @Param()

--- a/packages/jin-frame/docs/method/validation.md
+++ b/packages/jin-frame/docs/method/validation.md
@@ -88,10 +88,10 @@ class UserValidator extends Validator<
 ### Usage with JinFrame
 
 ```typescript
+@Validator(new UserValidator()) // Register validator
 @Post({
   host: 'https://api.example.com',
   path: '/users',
-  validator: new UserValidator(), // Register validator
 })
 class CreateUserFrame extends JinFrame<UserData> {
   @Body()
@@ -192,10 +192,10 @@ class ProductValidator extends Validator<
 }
 
 // 2. Apply to Frame
+@Validator(new ProductValidator()) // Register validator
 @Get({
   host: 'https://api.shop.com',
   path: '/products/:id',
-  validator: new ProductValidator(),
 })
 class GetProductFrame extends JinFrame<Product> {
   @Param()


### PR DESCRIPTION
- Changed comments in the validation documentation to improve clarity, replacing "검증기 등록" with "Register validator" in both Korean and English sections.
- Ensured consistency in documentation style across different language versions.