### PR TITLE
feat(hooks): add init-hooks script to configure git hooks path

### DIFF
--- a/init-hooks.sh
+++ b/init-hooks.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+git config core.hooksPath .hooks

--- a/packages/jin-frame/docs/.vitepress/config.mts
+++ b/packages/jin-frame/docs/.vitepress/config.mts
@@ -7,8 +7,8 @@ const getThemeConfig = (_locale?: string) => {
   const locale = _locale != null ? `/${_locale}` : '';
 
   const logo = {
-    light: './docs/assets/jin-frame-brand-icon.png',
-    dark: './docs/assets/jin-frame-brand-icon.png',
+    light: `${base}/assets/jin-frame-brand-icon.png`,
+    dark: `${base}/assets/jin-frame-brand-icon.png`,
   };
 
   const nav = [


### PR DESCRIPTION
- Introduced a new script `init-hooks.sh` to set the git hooks path to `.hooks`.
- This allows for better management of custom git hooks within the project.