### PR TITLE
refactor(fields): simplify field option structure by removing nested option wrapper

### DIFF
--- a/packages/jin-frame/src/decorators/fields/handlers/getFieldMetadata.test.ts
+++ b/packages/jin-frame/src/decorators/fields/handlers/getFieldMetadata.test.ts
@@ -47,69 +47,59 @@ describe('getFieldMetadata', () => {
     expect(metas).toMatchObject({
       param: [
         {
+          type: 'param',
           key: 'name',
-          option: {
-            type: 'param',
-            comma: false,
-            bit: {
-              enable: false,
-              withZero: false,
-            },
-            encode: true,
-            formatters: undefined,
-            replaceAt: undefined,
+          comma: false,
+          bit: {
+            enable: false,
+            withZero: false,
           },
+          encode: true,
+          formatters: undefined,
+          replaceAt: undefined,
         },
       ],
       body: [
         {
+          type: 'body',
           key: 'affiliations',
-          option: {
-            type: 'body',
-            replaceAt: undefined,
-            encode: true,
-          },
+          replaceAt: undefined,
+          encode: true,
         },
       ],
       objectBody: [
         {
+          type: 'object-body',
           key: 'ability',
-          option: {
-            type: 'object-body',
-            encode: true,
-            order: 9007199254740991,
-          },
+          encode: true,
+          order: 9007199254740991,
         },
       ],
       header: [
         {
+          type: 'header',
           key: 'authorization',
-          option: {
-            type: 'header',
-            bit: {
-              enable: false,
-              withZero: false,
-            },
-            replaceAt: 'Authorization',
-            comma: false,
-            encode: true,
+          bit: {
+            enable: false,
+            withZero: false,
           },
+          replaceAt: 'Authorization',
+          comma: false,
+          encode: true,
         },
       ],
       query: [
         {
           key: 'age',
-          option: {
-            type: 'query',
-            comma: false,
-            bit: {
-              enable: false,
-              withZero: false,
-            },
-            encode: true,
-            formatters: undefined,
-            replaceAt: undefined,
+          type: 'query',
+          comma: false,
+          bit: {
+            enable: false,
+            withZero: false,
           },
+          encode: true,
+          formatters: undefined,
+          replaceAt: undefined,
         },
       ],
     });

--- a/packages/jin-frame/src/frames/AbstractJinFrame.ts
+++ b/packages/jin-frame/src/frames/AbstractJinFrame.ts
@@ -111,7 +111,6 @@ export abstract class AbstractJinFrame<TPASS> {
 
   public getOption<K extends keyof IFrameOption>(kind: K): IFrameOption[K] {
     // TypeScript inference limitation with complex interface types
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return this.$_option[kind];
   }
 
@@ -189,7 +188,7 @@ export abstract class AbstractJinFrame<TPASS> {
     const fields = getFieldMetadata(this.constructor.prototype, entries);
 
     // stage 02. each request parameter apply option
-    const queryMap = new Map(fields.query.map((query) => [query.key, query.option]));
+    const queryMap = new Map(fields.query.map((query) => [query.key, query]));
     const queries = getQuerystringMap(this as Record<string, unknown>, fields.query); // create querystring information
     const headers = flatStringMap(getQuerystringMap(this as Record<string, unknown>, fields.header)); // create header information
     const paths = flatStringMap(getQuerystringMap(this as Record<string, unknown>, fields.param)); // create param information
@@ -206,16 +205,7 @@ export abstract class AbstractJinFrame<TPASS> {
         return undefined;
       }
 
-      return getBodyMap(this as Record<string, unknown>, [
-        ...fields.body.map((body) => ({
-          key: body.key,
-          option: body.option,
-        })),
-        ...fields.objectBody.map((body) => ({
-          key: body.key,
-          option: body.option,
-        })),
-      ]);
+      return getBodyMap(this as Record<string, unknown>, [...fields.body, ...fields.objectBody]);
     })();
 
     // stage 04. set debuggint variable

--- a/packages/jin-frame/src/interfaces/field/ICommonFieldOption.ts
+++ b/packages/jin-frame/src/interfaces/field/ICommonFieldOption.ts
@@ -1,4 +1,7 @@
 export interface ICommonFieldOption {
   /** Do encodeURIComponent execution, this option only executed in query parameter */
   encode?: boolean;
+
+  /** The field key name */
+  key: string;
 }

--- a/packages/jin-frame/src/processors/getBodyMap.ts
+++ b/packages/jin-frame/src/processors/getBodyMap.ts
@@ -1,4 +1,3 @@
-import type { IBodyField } from '#interfaces/field/body/IBodyField';
 import type { IBodyFieldOption } from '#interfaces/field/body/IBodyFieldOption';
 import type { IObjectBodyFieldOption } from '#interfaces/field/body/IObjectBodyFieldOption';
 import { getBodyField } from '#processors/getBodyField';
@@ -11,7 +10,7 @@ import { atOrThrow } from 'my-easy-fp';
 
 export function getBodyMap<T extends Record<string, unknown>>(
   thisFrame: T,
-  fields: IBodyField[],
+  fields: (IBodyFieldOption | IObjectBodyFieldOption)[],
 ): Record<string, unknown> | TSupportPrimitiveType | TSupportArrayType | unknown[] {
   const bodies: unknown[] = [];
   const objectBodies: unknown[] = [];
@@ -20,13 +19,11 @@ export function getBodyMap<T extends Record<string, unknown>>(
     bodies: { key: string; option: IBodyFieldOption }[];
     objectBodies: { key: string; option: IObjectBodyFieldOption }[];
   }>(
-    (aggregated, field) => {
-      const { option } = field;
-
+    (aggregated, option) => {
       if (option.type === 'body') {
-        aggregated.bodies.push({ key: field.key, option });
+        aggregated.bodies.push({ key: option.key, option });
       } else {
-        aggregated.objectBodies.push({ key: field.key, option });
+        aggregated.objectBodies.push({ key: option.key, option });
       }
 
       return aggregated;

--- a/packages/jin-frame/src/processors/getDefaultOption.test.ts
+++ b/packages/jin-frame/src/processors/getDefaultOption.test.ts
@@ -14,6 +14,7 @@ describe('getDefaultQueryFieldOption', () => {
     const option = getDefaultQueryFieldOption();
 
     expect(option).toEqual({
+      key: '',
       type: 'query',
       formatters: undefined,
       comma: false,
@@ -21,7 +22,7 @@ describe('getDefaultQueryFieldOption', () => {
         enable: false,
         withZero: false,
       },
-      keyFormat: undefined,
+      keyForamt: undefined,
       encode: true,
     });
   });
@@ -31,6 +32,7 @@ describe('getDefaultQueryFieldOption', () => {
     const option = getDefaultQueryFieldOption({ formatters: f });
 
     expect(option).toMatchObject({
+      key: '',
       type: 'query',
       formatters: f,
       comma: false,
@@ -45,6 +47,7 @@ describe('getDefaultQueryFieldOption', () => {
   it('comma', () => {
     const r01 = getDefaultQueryFieldOption({ comma: true });
     expect(r01).toMatchObject({
+      key: '',
       type: 'query',
       formatters: undefined,
       comma: true,
@@ -59,6 +62,7 @@ describe('getDefaultQueryFieldOption', () => {
   it('comma', () => {
     const r01 = getDefaultQueryFieldOption({ encode: false });
     expect(r01).toMatchObject({
+      key: '',
       type: 'query',
       formatters: undefined,
       comma: false,
@@ -102,6 +106,7 @@ describe('getDefaultParamFieldOption', () => {
     const option = getDefaultParamFieldOption();
 
     expect(option).toEqual({
+      key: '',
       type: 'param',
       formatters: undefined,
       comma: false,
@@ -189,6 +194,7 @@ describe('getDefaultBodyFieldOption', () => {
     const option = getDefaultBodyFieldOption();
 
     expect(option).toEqual({
+      key: '',
       type: 'body',
       replaceAt: undefined,
       encode: true,
@@ -242,6 +248,7 @@ describe('getDefaultObjectBodyFieldOption', () => {
     const option = getDefaultObjectBodyFieldOption();
 
     expect(option).toEqual({
+      key: '',
       type: 'object-body',
       encode: true,
       order: Number.MAX_SAFE_INTEGER,
@@ -295,6 +302,7 @@ describe('getDefaultHeaderFieldOption', () => {
     const option = getDefaultHeaderFieldOption();
 
     expect(option).toEqual({
+      key: '',
       type: 'header',
       bit: {
         enable: false,

--- a/packages/jin-frame/src/processors/getDefaultOption.ts
+++ b/packages/jin-frame/src/processors/getDefaultOption.ts
@@ -9,6 +9,7 @@ export function getDefaultQueryFieldOption(
   option?: Partial<IQueryFieldOption> | Omit<Partial<IQueryFieldOption>, 'type'>,
 ): IQueryFieldOption {
   return {
+    key: '',
     type: 'query',
     formatters: option?.formatters ?? undefined,
     comma: option?.comma ?? false,
@@ -26,6 +27,7 @@ export function getDefaultParamFieldOption(
   option?: Partial<IParamFieldOption> | Omit<Partial<IParamFieldOption>, 'type'>,
 ): IParamFieldOption {
   return {
+    key: '',
     type: 'param',
     formatters: option?.formatters ?? undefined,
     comma: option?.comma ?? false,
@@ -43,6 +45,7 @@ export function getDefaultBodyFieldOption(
 ): IBodyFieldOption {
   if (option == null) {
     return {
+      key: '',
       type: 'body',
       replaceAt: undefined,
       encode: true,
@@ -51,6 +54,7 @@ export function getDefaultBodyFieldOption(
 
   if ('formatters' in option) {
     return {
+      key: '',
       type: 'body',
       formatters: option.formatters ?? undefined,
       replaceAt: option.replaceAt ?? undefined,
@@ -59,6 +63,7 @@ export function getDefaultBodyFieldOption(
   }
 
   return {
+    key: '',
     type: 'body',
     replaceAt: option.replaceAt ?? undefined,
     encode: option.encode ?? true,
@@ -70,6 +75,7 @@ export function getDefaultObjectBodyFieldOption(
 ): IObjectBodyFieldOption {
   if (option == null) {
     return {
+      key: '',
       type: 'object-body',
       encode: true,
       order: Number.MAX_SAFE_INTEGER,
@@ -78,6 +84,7 @@ export function getDefaultObjectBodyFieldOption(
 
   if ('formatters' in option) {
     return {
+      key: '',
       type: 'object-body',
       formatters: option.formatters ?? undefined,
       encode: option.encode ?? true,
@@ -86,6 +93,7 @@ export function getDefaultObjectBodyFieldOption(
   }
 
   return {
+    key: '',
     type: 'object-body',
     encode: option.encode ?? true,
     order: option.order ?? Number.MAX_SAFE_INTEGER,
@@ -97,6 +105,7 @@ export function getDefaultHeaderFieldOption(
 ): IHeaderFieldOption {
   if (option == null) {
     return {
+      key: '',
       type: 'header',
       bit: { enable: false, withZero: false },
       encode: true,
@@ -106,6 +115,7 @@ export function getDefaultHeaderFieldOption(
 
   if ('formatters' in option) {
     return {
+      key: '',
       type: 'header',
       bit: { enable: false, withZero: false },
       formatters: option.formatters ?? undefined,
@@ -116,6 +126,7 @@ export function getDefaultHeaderFieldOption(
   }
 
   return {
+    key: '',
     type: 'header',
     replaceAt: option.replaceAt ?? undefined,
     bit: { enable: false, withZero: false },

--- a/packages/jin-frame/src/processors/getQuerystringMap.test.ts
+++ b/packages/jin-frame/src/processors/getQuerystringMap.test.ts
@@ -8,7 +8,7 @@ describe('getQuerystringMap', () => {
       {
         val: { name: 'ironman' },
       },
-      [{ key: 'val', option: { type: 'query', bit: { enable: false, withZero: false }, comma: false } }],
+      [{ key: 'val', type: 'query', bit: { enable: false, withZero: false }, comma: false }],
     );
 
     expect(map).toEqual({ val: '{"name":"ironman"}' });
@@ -16,7 +16,7 @@ describe('getQuerystringMap', () => {
 
   it('should return bitwized when array number', () => {
     const result = getQuerystringMap({ bit: [0b1, 0b10, 0b1000] }, [
-      { key: 'bit', option: { type: 'query', bit: { enable: true, withZero: false }, comma: false } },
+      { key: 'bit', type: 'query', bit: { enable: true, withZero: false }, comma: false },
     ]);
 
     expect(result).toMatchObject({ bit: '11' });
@@ -24,7 +24,7 @@ describe('getQuerystringMap', () => {
 
   it('should return bitwized 0 when array number', () => {
     const result = getQuerystringMap({ bit: [0] }, [
-      { key: 'bit', option: { type: 'query', bit: { enable: true, withZero: true }, comma: false } },
+      { key: 'bit', type: 'query', bit: { enable: true, withZero: true }, comma: false },
     ]);
 
     expect(result).toMatchObject({ bit: '0' });
@@ -32,7 +32,7 @@ describe('getQuerystringMap', () => {
 
   it('should return empty map when zero number and withZero set false', () => {
     const result = getQuerystringMap({ bit: [0] }, [
-      { key: 'bit', option: { type: 'query', bit: { enable: true, withZero: false }, comma: false } },
+      { key: 'bit', type: 'query', bit: { enable: true, withZero: false }, comma: false },
     ]);
 
     expect(result).toMatchObject({});
@@ -42,14 +42,12 @@ describe('getQuerystringMap', () => {
     const r01 = getQuerystringMap({ fm: '2023-01-20' }, [
       {
         key: 'fm',
-        option: {
-          type: 'query',
-          bit: { enable: false, withZero: false },
-          comma: false,
-          formatters: {
-            string: (v) => parse(v, 'yyyy-MM-dd', new Date()),
-            dateTime: (dt) => format(dt, 'dd/MMM/yyyy'),
-          },
+        type: 'query',
+        bit: { enable: false, withZero: false },
+        comma: false,
+        formatters: {
+          string: (v) => parse(v, 'yyyy-MM-dd', new Date()),
+          dateTime: (dt) => format(dt, 'dd/MMM/yyyy'),
         },
       },
     ]);
@@ -61,14 +59,12 @@ describe('getQuerystringMap', () => {
     const r01 = getQuerystringMap({ fm: ['2023-01-19', '2023-01-20'] }, [
       {
         key: 'fm',
-        option: {
-          type: 'query',
-          bit: { enable: false, withZero: false },
-          comma: true,
-          formatters: {
-            string: (v) => parse(v, 'yyyy-MM-dd', new Date()),
-            dateTime: (dt) => format(dt, 'dd/MMM/yyyy'),
-          },
+        type: 'query',
+        bit: { enable: false, withZero: false },
+        comma: true,
+        formatters: {
+          string: (v) => parse(v, 'yyyy-MM-dd', new Date()),
+          dateTime: (dt) => format(dt, 'dd/MMM/yyyy'),
         },
       },
     ]);
@@ -80,11 +76,9 @@ describe('getQuerystringMap', () => {
     const r01 = getQuerystringMap({ heroes: ['ironman', 'captain'] }, [
       {
         key: 'heroes',
-        option: {
-          type: 'query',
-          bit: { enable: false, withZero: false },
-          comma: true,
-        },
+        type: 'query',
+        bit: { enable: false, withZero: false },
+        comma: true,
       },
     ]);
 

--- a/packages/jin-frame/src/processors/getQuerystringMap.ts
+++ b/packages/jin-frame/src/processors/getQuerystringMap.ts
@@ -13,12 +13,12 @@ import * as dotProp from 'dot-prop';
 
 export function getQuerystringMap<T extends Record<string, unknown>>(
   thisFrame: T,
-  fields: { key: string; option: IQueryFieldOption | IParamFieldOption | IHeaderFieldOption }[],
+  fields: (IQueryFieldOption | IParamFieldOption | IHeaderFieldOption)[],
 ): Record<string, string | string[]> {
   const queries: Record<string, string | string[]> = {};
 
-  for (const field of fields) {
-    const { key: thisFrameAccessKey, option } = field;
+  for (const option of fields) {
+    const thisFrameAccessKey = option.key;
     const value: unknown = dotProp.get<unknown>(thisFrame, thisFrameAccessKey);
     const fieldKey = option.replaceAt ?? thisFrameAccessKey;
     const { formatters } = option;


### PR DESCRIPTION
- Remove nested option wrapper from field metadata structure
- Flatten ICommonFieldOption by adding key property directly
- Update getFieldMetadata to return flattened field options
- Simplify getQuerystringMap and getBodyMap parameter types
- Update all test cases to match new simplified structure
- Remove unnecessary nested object access in AbstractJinFrame

🤖 Generated with [Claude Code](https://claude.ai/code)