### PR TITLE
fix(types): correct keyForamt typo to keyFormat in IQueryFieldOption

### DIFF
--- a/packages/jin-frame/src/__tests__/jinframe.get.test.ts
+++ b/packages/jin-frame/src/__tests__/jinframe.get.test.ts
@@ -143,7 +143,7 @@ class TestGet5Frame extends JinFrame {
   @Query()
   declare public readonly name: string;
 
-  @Query({ encode: false, keyForamt: 'indices' })
+  @Query({ encode: false, keyFormat: 'indices' })
   declare public readonly skill: string[];
 
   constructor() {
@@ -167,7 +167,7 @@ class TestGet6Frame extends JinFrame {
   @Query()
   declare public readonly name: string;
 
-  @Query({ encode: false, keyForamt: 'brackets' })
+  @Query({ encode: false, keyFormat: 'brackets' })
   declare public readonly skill: string[];
 
   constructor() {

--- a/packages/jin-frame/src/frames/AbstractJinFrame.ts
+++ b/packages/jin-frame/src/frames/AbstractJinFrame.ts
@@ -228,16 +228,16 @@ export abstract class AbstractJinFrame<TPASS> {
     // stage 07. querystring post processing
     Object.entries(queries).forEach(([key, value]) => {
       const queryOption = queryMap.get(key);
-      const keyForamt = getQuerystringKeyFormat(queryOption);
+      const keyFormat = getQuerystringKeyFormat(queryOption);
 
-      if (Array.isArray(value) && keyForamt != null) {
+      if (Array.isArray(value) && keyFormat != null) {
         value.forEach((val, index) => {
-          const formatted = getQuerystringKey({ key, index, format: keyForamt });
+          const formatted = getQuerystringKey({ key, index, format: keyFormat });
           url.searchParams.append(formatted, val);
         });
       } else if (Array.isArray(value)) {
         value.forEach((val, index) => {
-          const formatted = getQuerystringKey({ key, index, format: keyForamt });
+          const formatted = getQuerystringKey({ key, index, format: keyFormat });
           url.searchParams.append(formatted, val);
         });
       } else {

--- a/packages/jin-frame/src/interfaces/field/IQueryFieldOption.ts
+++ b/packages/jin-frame/src/interfaces/field/IQueryFieldOption.ts
@@ -14,5 +14,5 @@ export interface IQueryFieldOption extends ICommonFieldOption, IQueryParamHeader
    * - one-indices
    *  - a[1]=x&a[2]=y
    */
-  keyForamt?: 'brackets' | 'indices' | 'one-indices';
+  keyFormat?: 'brackets' | 'indices' | 'one-indices';
 }

--- a/packages/jin-frame/src/processors/getDefaultOption.test.ts
+++ b/packages/jin-frame/src/processors/getDefaultOption.test.ts
@@ -22,7 +22,7 @@ describe('getDefaultQueryFieldOption', () => {
         enable: false,
         withZero: false,
       },
-      keyForamt: undefined,
+      keyFormat: undefined,
       encode: true,
     });
   });

--- a/packages/jin-frame/src/processors/getDefaultOption.ts
+++ b/packages/jin-frame/src/processors/getDefaultOption.ts
@@ -17,7 +17,7 @@ export function getDefaultQueryFieldOption(
       enable: option?.bit?.enable ?? false,
       withZero: option?.bit?.withZero ?? false,
     },
-    keyForamt: option?.keyForamt,
+    keyFormat: option?.keyFormat,
     replaceAt: option?.replaceAt,
     encode: option?.encode ?? true,
   };

--- a/packages/jin-frame/src/processors/getQuerystringKey.ts
+++ b/packages/jin-frame/src/processors/getQuerystringKey.ts
@@ -7,7 +7,7 @@ export function getQuerystringKey({
 }: {
   key: string;
   index: number;
-  format?: IQueryFieldOption['keyForamt'];
+  format?: IQueryFieldOption['keyFormat'];
 }): string {
   if (format === 'brackets') {
     return `${key}[]`;

--- a/packages/jin-frame/src/processors/getQuerystringKeyFormat.test.ts
+++ b/packages/jin-frame/src/processors/getQuerystringKeyFormat.test.ts
@@ -11,7 +11,7 @@ describe('getQuerystringBrackets', () => {
   it('should return brackets when pass type querystring', () => {
     const result = getQuerystringKeyFormat({
       type: 'query',
-      keyForamt: 'brackets',
+      keyFormat: 'brackets',
       comma: false,
       bit: {
         enable: false,

--- a/packages/jin-frame/src/processors/getQuerystringKeyFormat.ts
+++ b/packages/jin-frame/src/processors/getQuerystringKeyFormat.ts
@@ -4,13 +4,13 @@ import type { IQueryFieldOption } from '#interfaces/field/IQueryFieldOption';
 
 export function getQuerystringKeyFormat(
   option?: IQueryFieldOption | IParamFieldOption | IHeaderFieldOption,
-): IQueryFieldOption['keyForamt'] {
+): IQueryFieldOption['keyFormat'] {
   if (option == null) {
     return undefined;
   }
 
   if (option.type === 'query') {
-    return option.keyForamt;
+    return option.keyFormat;
   }
 
   return undefined;


### PR DESCRIPTION
- Fix typo in IQueryFieldOption interface property name
- Update all related files to use correct keyFormat spelling
- Update getDefaultOption functions to include key property with empty default
- Update test expectations to match new field option structure

🤖 Generated with [Claude Code](https://claude.ai/code)