### PR TITLE
refactor(processors): simplify field option structure by removing nes…

### DIFF
--- a/packages/jin-frame/.configs/typedoc.json
+++ b/packages/jin-frame/.configs/typedoc.json
@@ -12,7 +12,6 @@
   "exclude": [
     "**/__tests__/*",
     "**/*.test.ts",
-    "**/*.test.ts",
     "**/*.test.tsx",
     "**/*.spec.ts",
     "**/*.spec.tsx",

--- a/packages/jin-frame/src/processors/getBodyField.test.ts
+++ b/packages/jin-frame/src/processors/getBodyField.test.ts
@@ -7,12 +7,12 @@ describe('getBodyField', () => {
     const b = () => {};
     const c = Symbol(1);
 
-    const r01 = getBodyField(1, { key: 'name', option: { type: 'body' } });
-    const r02 = getBodyField(BigInt(1), { key: 'name', option: { type: 'body' } });
-    const r03 = getBodyField(c, { key: 'name', option: { type: 'body' } });
-    const r04 = getBodyField(a, { key: 'name', option: { type: 'body' } });
-    const r05 = getBodyField(b, { key: 'name', option: { type: 'body' } });
-    const r06 = getBodyField([1], { key: 'name', option: { type: 'body' } });
+    const r01 = getBodyField(1, { key: 'name', type: 'body' });
+    const r02 = getBodyField(BigInt(1), { key: 'name', type: 'body' });
+    const r03 = getBodyField(c, { key: 'name', type: 'body' });
+    const r04 = getBodyField(a, { key: 'name', type: 'body' });
+    const r05 = getBodyField(b, { key: 'name', type: 'body' });
+    const r06 = getBodyField([1], { key: 'name', type: 'body' });
 
     expect(r01).toEqual(1);
     expect(r02).toEqual(BigInt(1));
@@ -26,11 +26,9 @@ describe('getBodyField', () => {
     const data = { name: null };
     const results = getBodyField(data, {
       key: 'name',
-      option: {
-        type: 'body',
-        formatters: {
-          number: (v) => `${v}`,
-        },
+      type: 'body',
+      formatters: {
+        number: (v) => `${v}`,
       },
     });
 
@@ -42,11 +40,9 @@ describe('getBodyField', () => {
       { name: 1 },
       {
         key: 'name',
-        option: {
-          type: 'body',
-          formatters: {
-            number: (v) => `${v}`,
-          },
+        type: 'body',
+        formatters: {
+          number: (v) => `${v}`,
         },
       },
     );
@@ -59,11 +55,9 @@ describe('getBodyField', () => {
       { name: [1] },
       {
         key: 'name',
-        option: {
-          type: 'body',
-          formatters: {
-            number: (v) => `${v}`,
-          },
+        type: 'body',
+        formatters: {
+          number: (v) => `${v}`,
         },
       },
     );
@@ -76,11 +70,9 @@ describe('getBodyField', () => {
       { name: [1] },
       {
         key: 'name',
-        option: {
-          type: 'body',
-          formatters: {
-            number: (v) => `${v}`,
-          },
+        type: 'body',
+        formatters: {
+          number: (v) => `${v}`,
         },
       },
     );
@@ -93,12 +85,10 @@ describe('getBodyField', () => {
       { name: { age: 10 } },
       {
         key: 'name',
-        option: {
-          type: 'body',
-          formatters: {
-            findFrom: 'age',
-            number: (v) => `${v}`,
-          },
+        type: 'body',
+        formatters: {
+          findFrom: 'age',
+          number: (v) => `${v}`,
         },
       },
     );
@@ -111,12 +101,10 @@ describe('getBodyField', () => {
       { name: { age: 10 } },
       {
         key: 'name',
-        option: {
-          type: 'body',
-          formatters: {
-            findFrom: 'age',
-            number: (v) => `${v}`,
-          },
+        type: 'body',
+        formatters: {
+          findFrom: 'age',
+          number: (v) => `${v}`,
         },
       },
     );

--- a/packages/jin-frame/src/processors/getBodyField.ts
+++ b/packages/jin-frame/src/processors/getBodyField.ts
@@ -9,7 +9,7 @@ import type { TSupportArrayType } from '#tools/type-utilities/TSupportArrayType'
 import type { TSupportPrimitiveType } from '#tools/type-utilities/TSupportPrimitiveType';
 import * as dotProp from 'dot-prop';
 
-export function getBodyField(thisFrame: unknown, field: { key: string; option: IBodyFieldOption }): unknown {
+export function getBodyField(thisFrame: unknown, field: IBodyFieldOption): unknown {
   if (
     isValidPrimitiveWithDateType(thisFrame) ||
     typeof thisFrame === 'bigint' ||
@@ -20,10 +20,10 @@ export function getBodyField(thisFrame: unknown, field: { key: string; option: I
     return thisFrame;
   }
 
-  const { key: accessKey, option } = field;
+  const accessKey = field.key;
   const value: unknown = (thisFrame as Record<string, unknown>)[accessKey];
-  const formatters: TSingleBodyFormatter[] = getBodyFormatters(field.option.formatters);
-  const replaceKey = option.replaceAt ?? accessKey;
+  const formatters: TSingleBodyFormatter[] = getBodyFormatters(field.formatters);
+  const replaceKey = field.replaceAt ?? accessKey;
 
   // case 02. nullable value
   if (value == null) {

--- a/packages/jin-frame/src/processors/getBodyMap.ts
+++ b/packages/jin-frame/src/processors/getBodyMap.ts
@@ -16,14 +16,14 @@ export function getBodyMap<T extends Record<string, unknown>>(
   const objectBodies: unknown[] = [];
 
   const classifed = fields.reduce<{
-    bodies: { key: string; option: IBodyFieldOption }[];
-    objectBodies: { key: string; option: IObjectBodyFieldOption }[];
+    bodies: IBodyFieldOption[];
+    objectBodies: IObjectBodyFieldOption[];
   }>(
     (aggregated, option) => {
       if (option.type === 'body') {
-        aggregated.bodies.push({ key: option.key, option });
+        aggregated.bodies.push(option);
       } else {
-        aggregated.objectBodies.push({ key: option.key, option });
+        aggregated.objectBodies.push(option);
       }
 
       return aggregated;
@@ -34,14 +34,14 @@ export function getBodyMap<T extends Record<string, unknown>>(
     },
   );
 
-  classifed.objectBodies = classifed.objectBodies.sort((l, r) => l.option.order - r.option.order);
+  classifed.objectBodies = classifed.objectBodies.sort((l, r) => l.order - r.order);
 
   for (const field of classifed.bodies) {
-    bodies.push(getBodyField(thisFrame, { key: field.key, option: field.option }));
+    bodies.push(getBodyField(thisFrame, field));
   }
 
   for (const field of classifed.objectBodies) {
-    objectBodies.push(getObjectBodyField(thisFrame, { key: field.key, option: field.option }));
+    objectBodies.push(getObjectBodyField(thisFrame, field));
   }
 
   // ------------------------------------------------------------------------------------

--- a/packages/jin-frame/src/processors/getObjectBodyField.test.ts
+++ b/packages/jin-frame/src/processors/getObjectBodyField.test.ts
@@ -6,12 +6,10 @@ describe('getObjectBodyField', () => {
     const data = BigInt(1);
     const results = getObjectBodyField(data, {
       key: 'name',
-      option: {
-        type: 'object-body',
-        order: Number.MAX_SAFE_INTEGER,
-        formatters: {
-          number: (v) => `primitive:${v}`,
-        },
+      type: 'object-body',
+      order: Number.MAX_SAFE_INTEGER,
+      formatters: {
+        number: (v) => `primitive:${v}`,
       },
     });
 
@@ -22,12 +20,10 @@ describe('getObjectBodyField', () => {
     const data = { name: null };
     const results = getObjectBodyField(data, {
       key: 'name',
-      option: {
-        type: 'object-body',
-        order: Number.MAX_SAFE_INTEGER,
-        formatters: {
-          number: (v) => `${v}`,
-        },
+      type: 'object-body',
+      order: Number.MAX_SAFE_INTEGER,
+      formatters: {
+        number: (v) => `${v}`,
       },
     });
 

--- a/packages/jin-frame/src/processors/getObjectBodyField.ts
+++ b/packages/jin-frame/src/processors/getObjectBodyField.ts
@@ -8,10 +8,7 @@ import type { TSupportPrimitiveType } from '#tools/type-utilities/TSupportPrimit
 import { bodyFormatEach } from '#tools/formatters/bodyFormatEach';
 import { formatEach } from '#tools/formatters/formatEach';
 
-export function getObjectBodyField(
-  thisFrame: unknown,
-  field: { key: string; option: IObjectBodyFieldOption },
-): unknown {
+export function getObjectBodyField(thisFrame: unknown, field: IObjectBodyFieldOption): unknown {
   if (
     isValidPrimitiveWithDateType(thisFrame) ||
     typeof thisFrame === 'bigint' ||
@@ -22,9 +19,9 @@ export function getObjectBodyField(
     return thisFrame;
   }
 
-  const { key: accessKey } = field;
+  const accessKey = field.key;
   const value: unknown = (thisFrame as Record<string, unknown>)[accessKey];
-  const formatters: TSingleBodyFormatter[] = getBodyFormatters(field.option.formatters);
+  const formatters: TSingleBodyFormatter[] = getBodyFormatters(field.formatters);
 
   // case 02. nullable value
   if (value == null) {

--- a/packages/jin-frame/src/processors/getQuerystringKeyFormat.test.ts
+++ b/packages/jin-frame/src/processors/getQuerystringKeyFormat.test.ts
@@ -10,6 +10,7 @@ describe('getQuerystringBrackets', () => {
 
   it('should return brackets when pass type querystring', () => {
     const result = getQuerystringKeyFormat({
+      key: 'test',
       type: 'query',
       keyFormat: 'brackets',
       comma: false,
@@ -17,6 +18,7 @@ describe('getQuerystringBrackets', () => {
         enable: false,
         withZero: false,
       },
+      cacheKeyExclude: false,
     });
 
     expect(result).toEqual('brackets');
@@ -24,12 +26,14 @@ describe('getQuerystringBrackets', () => {
 
   it('should return brackets when pass type param', () => {
     const result = getQuerystringKeyFormat({
+      key: 'test',
       type: 'param',
       comma: false,
       bit: {
         enable: false,
         withZero: false,
       },
+      cacheKeyExclude: false,
     });
 
     expect(result).toBeUndefined();

--- a/packages/jin-frame/src/processors/getQuerystringMap.test.ts
+++ b/packages/jin-frame/src/processors/getQuerystringMap.test.ts
@@ -8,7 +8,7 @@ describe('getQuerystringMap', () => {
       {
         val: { name: 'ironman' },
       },
-      [{ key: 'val', type: 'query', bit: { enable: false, withZero: false }, comma: false }],
+      [{ key: 'val', type: 'query', bit: { enable: false, withZero: false }, comma: false, cacheKeyExclude: false }],
     );
 
     expect(map).toEqual({ val: '{"name":"ironman"}' });
@@ -16,7 +16,7 @@ describe('getQuerystringMap', () => {
 
   it('should return bitwized when array number', () => {
     const result = getQuerystringMap({ bit: [0b1, 0b10, 0b1000] }, [
-      { key: 'bit', type: 'query', bit: { enable: true, withZero: false }, comma: false },
+      { key: 'bit', type: 'query', bit: { enable: true, withZero: false }, comma: false, cacheKeyExclude: false },
     ]);
 
     expect(result).toMatchObject({ bit: '11' });
@@ -24,7 +24,7 @@ describe('getQuerystringMap', () => {
 
   it('should return bitwized 0 when array number', () => {
     const result = getQuerystringMap({ bit: [0] }, [
-      { key: 'bit', type: 'query', bit: { enable: true, withZero: true }, comma: false },
+      { key: 'bit', type: 'query', bit: { enable: true, withZero: true }, comma: false, cacheKeyExclude: false },
     ]);
 
     expect(result).toMatchObject({ bit: '0' });
@@ -32,7 +32,7 @@ describe('getQuerystringMap', () => {
 
   it('should return empty map when zero number and withZero set false', () => {
     const result = getQuerystringMap({ bit: [0] }, [
-      { key: 'bit', type: 'query', bit: { enable: true, withZero: false }, comma: false },
+      { key: 'bit', type: 'query', bit: { enable: true, withZero: false }, comma: false, cacheKeyExclude: false },
     ]);
 
     expect(result).toMatchObject({});
@@ -45,6 +45,7 @@ describe('getQuerystringMap', () => {
         type: 'query',
         bit: { enable: false, withZero: false },
         comma: false,
+        cacheKeyExclude: false,
         formatters: {
           string: (v) => parse(v, 'yyyy-MM-dd', new Date()),
           dateTime: (dt) => format(dt, 'dd/MMM/yyyy'),
@@ -62,6 +63,7 @@ describe('getQuerystringMap', () => {
         type: 'query',
         bit: { enable: false, withZero: false },
         comma: true,
+        cacheKeyExclude: false,
         formatters: {
           string: (v) => parse(v, 'yyyy-MM-dd', new Date()),
           dateTime: (dt) => format(dt, 'dd/MMM/yyyy'),
@@ -79,6 +81,7 @@ describe('getQuerystringMap', () => {
         type: 'query',
         bit: { enable: false, withZero: false },
         comma: true,
+        cacheKeyExclude: false,
       },
     ]);
 


### PR DESCRIPTION
…ted option wrapper

Remove the nested `option` wrapper from field parameters in body and object body processors to streamline the API and improve code clarity.

🤖 Generated with [Claude Code](https://claude.ai/code)