### PR TITLE
refactor(dedupe): extract DedupeResult interface and improve debug info

### DIFF
--- a/packages/jin-frame/src/frames/RequestDedupeManager.test.ts
+++ b/packages/jin-frame/src/frames/RequestDedupeManager.test.ts
@@ -22,7 +22,7 @@ describe('RequestDedupeManager', () => {
 
       const result = await RequestDedupeManager.dedupe(cacheKey, mockRequester);
 
-      expect(result.response).toBe(mockResponse);
+      expect(result.reply).toBe(mockResponse);
       expect(result.isDeduped).toBe(false);
       expect(mockRequester).toHaveBeenCalledTimes(1);
       expect(RequestDedupeManager.getPendingRequestsCount()).toBe(0);
@@ -53,11 +53,11 @@ describe('RequestDedupeManager', () => {
       ]);
 
       expect(mockRequester).toHaveBeenCalledTimes(1);
-      expect(result1.response).toBe(mockResponse);
+      expect(result1.reply).toBe(mockResponse);
       expect(result1.isDeduped).toBe(false);
-      expect(result2.response).toBe(mockResponse);
+      expect(result2.reply).toBe(mockResponse);
       expect(result2.isDeduped).toBe(true);
-      expect(result3.response).toBe(mockResponse);
+      expect(result3.reply).toBe(mockResponse);
       expect(result3.isDeduped).toBe(true);
       expect(RequestDedupeManager.getPendingRequestsCount()).toBe(0);
     });
@@ -89,9 +89,9 @@ describe('RequestDedupeManager', () => {
 
       expect(mockRequester1).toHaveBeenCalledTimes(1);
       expect(mockRequester2).toHaveBeenCalledTimes(1);
-      expect(result1.response).toBe(mockResponse1);
+      expect(result1.reply).toBe(mockResponse1);
       expect(result1.isDeduped).toBe(false);
-      expect(result2.response).toBe(mockResponse2);
+      expect(result2.reply).toBe(mockResponse2);
       expect(result2.isDeduped).toBe(false);
     });
 
@@ -176,9 +176,9 @@ describe('RequestDedupeManager', () => {
 
       expect(mockRequester1).toHaveBeenCalledTimes(1);
       expect(mockRequester2).toHaveBeenCalledTimes(1);
-      expect(result1.response).toBe(mockResponse1);
+      expect(result1.reply).toBe(mockResponse1);
       expect(result1.isDeduped).toBe(false);
-      expect(result2.response).toBe(mockResponse2);
+      expect(result2.reply).toBe(mockResponse2);
       expect(result2.isDeduped).toBe(false);
     });
 
@@ -202,8 +202,8 @@ describe('RequestDedupeManager', () => {
 
       const result = await RequestDedupeManager.dedupe<TestData>(cacheKey, mockRequester);
 
-      expect(result.response.data.id).toBe(1);
-      expect(result.response.data.name).toBe('test');
+      expect(result.reply.data.id).toBe(1);
+      expect(result.reply.data.name).toBe('test');
       expect(result.isDeduped).toBe(false);
     });
   });
@@ -287,7 +287,7 @@ describe('RequestDedupeManager', () => {
       const mockRequester = vi.fn().mockResolvedValue(mockResponse);
       const result = await RequestDedupeManager.dedupe('', mockRequester);
 
-      expect(result.response).toBe(mockResponse);
+      expect(result.reply).toBe(mockResponse);
       expect(result.isDeduped).toBe(false);
       expect(mockRequester).toHaveBeenCalledTimes(1);
     });
@@ -305,7 +305,7 @@ describe('RequestDedupeManager', () => {
       const mockRequester = vi.fn().mockResolvedValue(mockResponse);
       const result = await RequestDedupeManager.dedupe(longKey, mockRequester);
 
-      expect(result.response).toBe(mockResponse);
+      expect(result.reply).toBe(mockResponse);
       expect(result.isDeduped).toBe(false);
       expect(RequestDedupeManager.hasPendingRequest(longKey)).toBe(false);
     });
@@ -347,7 +347,7 @@ describe('RequestDedupeManager', () => {
       }, 25);
 
       const result = await promise;
-      expect(result.response).toBe(mockResponse);
+      expect(result.reply).toBe(mockResponse);
       expect(result.isDeduped).toBe(false);
     });
 
@@ -369,7 +369,7 @@ describe('RequestDedupeManager', () => {
       expect(RequestDedupeManager.hasPendingRequest(cacheKey)).toBe(false);
 
       const result = await RequestDedupeManager.dedupe(cacheKey, successRequester);
-      expect(result.response).toBe(mockResponse);
+      expect(result.reply).toBe(mockResponse);
       expect(result.isDeduped).toBe(false);
       expect(RequestDedupeManager.hasPendingRequest(cacheKey)).toBe(false);
     });
@@ -388,7 +388,7 @@ describe('RequestDedupeManager', () => {
 
       const result = await RequestDedupeManager.dedupe(cacheKey, mockRequester);
 
-      expect(result.response.data).toBe(null);
+      expect(result.reply.data).toBe(null);
       expect(result.isDeduped).toBe(false);
       expect(mockRequester).toHaveBeenCalledTimes(1);
     });

--- a/packages/jin-frame/src/interfaces/DedupeResult.ts
+++ b/packages/jin-frame/src/interfaces/DedupeResult.ts
@@ -1,0 +1,12 @@
+import type { AxiosResponse } from 'axios';
+
+/**
+ * Result interface for deduplicated requests
+ * @template T - The response data type
+ */
+export interface DedupeResult<T> {
+  /** The response from the HTTP request */
+  reply: AxiosResponse<T>;
+  /** Whether this request was deduplicated (true) or was the original request (false) */
+  isDeduped: boolean;
+}

--- a/packages/jin-frame/src/interfaces/IDebugInfo.ts
+++ b/packages/jin-frame/src/interfaces/IDebugInfo.ts
@@ -1,23 +1,26 @@
 import type { AxiosRequestConfig } from 'axios';
 
 /**
- * Debugging information
+ * Debug information for HTTP requests
  */
 export interface IDebugInfo {
-  /** timestamp information at request start at */
+  /** Timestamp information when the request started */
   ts: {
-    /** unix timestamp style timestamp with milliseconds */
+    /** Unix timestamp with milliseconds as string */
     unix: string;
     /**
-     * iso timestamp style without hypen, only contain T character and dot
-     * ex> 20210721T112233.444
-     * */
+     * ISO timestamp without hyphens, containing only T character and dot
+     * @example "20210721T112233.444"
+     */
     iso: string;
   };
 
-  /** reqeust execute duration */
+  /** Request execution duration in milliseconds */
   duration: number;
 
-  /** AxiosRequestConfig */
+  /** Whether the request was deduplicated */
+  isDeduped: boolean;
+
+  /** Axios request configuration object */
   req: AxiosRequestConfig;
 }


### PR DESCRIPTION
- Extract DedupeResult interface to separate file for better organization
- Rename 'response' to 'reply' in DedupeResult for consistency
- Update all frame classes to properly handle dedupe status in debug info
- Improve JSDoc documentation for IDebugInfo with grammar fixes and missing field comments

🤖 Generated with [Claude Code](https://claude.ai/code)