### PR TITLE
fix(typos): correct spelling errors and restore deprecated authorizti…

### DIFF
--- a/packages/jin-frame/src/__tests__/header.builder.test.ts
+++ b/packages/jin-frame/src/__tests__/header.builder.test.ts
@@ -157,7 +157,7 @@ describe('JinEitherFrame - Header', () => {
     expect(req).toEqual(excpetation);
   });
 
-  it('T005-plain-object-type-array-comma-seperated', async () => {
+  it('T005-plain-object-type-array-comma-separated', async () => {
     const frame = Test005PostFrame.of({
       passing: 'hello',
       username: 'ironman',

--- a/packages/jin-frame/src/decorators/getFrameOption.ts
+++ b/packages/jin-frame/src/decorators/getFrameOption.ts
@@ -18,6 +18,7 @@ export function getFrameOption(method: TMethod, option?: Partial<Omit<IFrameOpti
     dedupe: option?.dedupe,
     security: option?.security,
     authorization: option?.authorization,
+    authoriztion: option?.authoriztion,
   };
 
   return frameOption;

--- a/packages/jin-frame/src/decorators/methods/handlers/getAllRequestMetaInherited.test.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/getAllRequestMetaInherited.test.ts
@@ -24,12 +24,12 @@ class GetAllRequestMetaInheritedTest003 extends GetAllRequestMetaInheritedTest00
 
 @Retry({ max: 2, interval: 500 })
 @Timeout(3000)
-@Put()
+@Put({ authoriztion: 'i-am-authorization-key' })
 class GetAllRequestMetaInheritedTest004 extends GetAllRequestMetaInheritedTest003 {}
 
 @Timeout(2000)
 @Validator(new BaseValidator({ type: 'exception' }))
-@Get({ path: 'overwrite/double/path' })
+@Get({ path: 'overwrite/double/path', authoriztion: 'i-am-authorization-key' })
 class GetAllRequestMetaInheritedTest005 extends GetAllRequestMetaInheritedTest004 {}
 
 describe('getAllRequestMetaInherited', () => {
@@ -50,6 +50,7 @@ describe('getAllRequestMetaInherited', () => {
             transformRequest: undefined,
             useInstance: false,
             userAgent: undefined,
+            authoriztion: 'i-am-authorization-key',
             pathPrefix: undefined,
             validator: undefined,
           },
@@ -82,6 +83,7 @@ describe('getAllRequestMetaInherited', () => {
             userAgent: undefined,
             retry: undefined,
             timeout: undefined,
+            authoriztion: undefined,
             pathPrefix: undefined,
             validator: undefined,
           },
@@ -98,6 +100,7 @@ describe('getAllRequestMetaInherited', () => {
             userAgent: undefined,
             retry: undefined,
             timeout: undefined,
+            authoriztion: undefined,
             pathPrefix: undefined,
             validator: undefined,
           },
@@ -114,6 +117,7 @@ describe('getAllRequestMetaInherited', () => {
             userAgent: undefined,
             retry: undefined,
             timeout: undefined,
+            authoriztion: undefined,
             pathPrefix: undefined,
             validator: undefined,
           },

--- a/packages/jin-frame/src/frames/JinFrame.test.ts
+++ b/packages/jin-frame/src/frames/JinFrame.test.ts
@@ -37,6 +37,7 @@ class CustomError extends Error {
 
 @Post({
   host: 'http://some.api.google.com/jinframe/:passing',
+  authoriztion: 'Bearer i-am-bearer-authorization-key',
 })
 class Test001PostFrame extends JinFrame<{ message: string }> {
   @Param()

--- a/packages/jin-frame/src/interfaces/field/IQueryParamHeaderCommonFieldOption.ts
+++ b/packages/jin-frame/src/interfaces/field/IQueryParamHeaderCommonFieldOption.ts
@@ -3,7 +3,7 @@ import type { IFormatter } from '#interfaces/options/IFormatter';
 export interface IQueryParamHeaderCommonFieldOption {
   /**
    * If you want to create depth or rename on field of body
-   * set this option dot seperated string. See below,
+   * set this option dot separated string. See below,
    *
    * @example
    * `data.test.ironman` convert to `{ "data.test.ironman": "value here" }`
@@ -12,9 +12,9 @@ export interface IQueryParamHeaderCommonFieldOption {
 
   /**
    * "comma" option only working querystring. If you want to process array parameter of querystring
-   * using by comma seperated string, set this option
+   * using by comma separated string, set this option
    *
-   * Comma seperated array parameter on querystring
+   * Comma separated array parameter on querystring
    */
   comma: boolean;
 

--- a/packages/jin-frame/src/interfaces/field/body/IBodyFieldOption.ts
+++ b/packages/jin-frame/src/interfaces/field/body/IBodyFieldOption.ts
@@ -7,7 +7,7 @@ export interface IBodyFieldOption extends ICommonFieldOption, ICommonCacheKeyExc
 
   /**
    * If you want to create depth or rename on field of body
-   * set this option dot seperated string. See below,
+   * set this option dot separated string. See below,
    *
    * @example
    * `data.test.ironman` convert to `{ data: { test: { ironman: "value here" } } }`

--- a/packages/jin-frame/src/interfaces/options/IFrameOption.ts
+++ b/packages/jin-frame/src/interfaces/options/IFrameOption.ts
@@ -77,6 +77,13 @@ export interface IFrameOption {
   authorization?: AuthorizationData;
 
   /**
+   * @deprecated Use `security` and `authorization` instead. This field will be removed in v5.0.0
+   * Legacy authorization field for backward compatibility
+   * eg. Bearer i-am-authorization-key
+   * */
+  authoriztion?: string | AxiosRequestConfig['auth'];
+
+  /**
    * validation configuration
    */
   validator?: BaseValidator;

--- a/packages/jin-frame/src/processors/getQuerystringMap.test.ts
+++ b/packages/jin-frame/src/processors/getQuerystringMap.test.ts
@@ -74,7 +74,7 @@ describe('getQuerystringMap', () => {
     expect(r01).toMatchObject({ fm: '19/Jan/2023,20/Jan/2023' });
   });
 
-  it('should return comma seperate string map when string array', () => {
+  it('should return comma separated string map when string array', () => {
     const r01 = getQuerystringMap({ heroes: ['ironman', 'captain'] }, [
       {
         key: 'heroes',

--- a/packages/jin-frame/src/tools/auth/getAuthorization.test.ts
+++ b/packages/jin-frame/src/tools/auth/getAuthorization.test.ts
@@ -88,4 +88,37 @@ describe('getAuthorization', () => {
     expect(result.authKey).toBe('Bearer dynamic-token');
     expect(result.securityHeaders).toEqual({ Authorization: 'Bearer dynamic-token' });
   });
+
+  // Backward compatibility tests for deprecated authoriztion field
+  it('should handle legacy authoriztion string field', () => {
+    const result = getAuthorization({}, { authoriztion: 'Bearer legacy-token' }, undefined);
+
+    expect(result.authKey).toBe('Bearer legacy-token');
+    expect(result.auth).toBeUndefined();
+  });
+
+  it('should handle legacy authoriztion auth object field', () => {
+    const auth = { username: 'legacy-user', password: 'legacy-pass' };
+    const result = getAuthorization({}, { authoriztion: auth }, undefined);
+
+    expect(result.authKey).toBeUndefined();
+    expect(result.auth).toEqual(auth);
+  });
+
+  it('should prioritize new security field over legacy authoriztion field', () => {
+    const provider = new BearerTokenProvider();
+    const result = getAuthorization(
+      {},
+      {
+        security: provider,
+        authorization: 'new-token',
+        authoriztion: 'legacy-token',
+      },
+      undefined,
+    );
+
+    // Should use new security system, not legacy
+    expect(result.authKey).toBe('Bearer new-token');
+    expect(result.securityHeaders).toEqual({ Authorization: 'Bearer new-token' });
+  });
 });

--- a/packages/jin-frame/src/tools/auth/getAuthorization.ts
+++ b/packages/jin-frame/src/tools/auth/getAuthorization.ts
@@ -52,7 +52,7 @@ import { applySecurityProviders } from '#tools/auth/applySecurityProviders';
  */
 export function getAuthorization(
   headers: Record<string, string>,
-  frameOption: Pick<IFrameOption, 'security' | 'authorization'>,
+  frameOption: Pick<IFrameOption, 'security' | 'authorization' | 'authoriztion'>,
   auth?: AxiosRequestConfig['auth'],
   dynamicAuth?: AuthorizationData,
 ): {
@@ -80,6 +80,15 @@ export function getAuthorization(
       securityHeaders: securityContext.headers,
       securityQueries: securityContext.queries,
     };
+  }
+
+  // Handle legacy authoriztion field (deprecated)
+  if (frameOption.authoriztion != null) {
+    if (typeof frameOption.authoriztion === 'string') {
+      return { authKey: frameOption.authoriztion, auth: undefined };
+    }
+
+    return { authKey: undefined, auth: frameOption.authoriztion };
   }
 
   return { authKey: undefined, auth: undefined };

--- a/packages/jin-frame/src/tools/formatters/stringifyExceptString.test.ts
+++ b/packages/jin-frame/src/tools/formatters/stringifyExceptString.test.ts
@@ -14,7 +14,7 @@ describe('stringifyExceptString', () => {
     vitest.useRealTimers();
   });
 
-  it('should stringified when primitive type which excpet string type', () => {
+  it('should stringified when primitive type which except string type', () => {
     const result = stringifyExceptString(1);
     expect(result).toEqual('1');
   });


### PR DESCRIPTION
…on field

- Fix "seperate" to "separated" in comments and test names
- Fix "excpet" to "except" in test name
- Restore deprecated authoriztion field for backward compatibility
- Add legacy authoriztion support in getAuthorization function with proper deprecation
- Add backward compatibility tests for authoriztion field
- Ensure new security system takes precedence over legacy authoriztion

This ensures existing users can continue using authoriztion field while migrating to the new security/authorization system without breaking changes.

🤖 Generated with [Claude Code](https://claude.ai/code)