### PR TITLE
feat(security): implement Security and Authorization decorators with comprehensive testing

### DIFF
--- a/packages/jin-frame/src/__tests__/security.test.ts
+++ b/packages/jin-frame/src/__tests__/security.test.ts
@@ -11,12 +11,15 @@ import { OAuth2Provider } from '#providers/security/OAuth2Provider';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Authorization } from '#decorators/methods/options/Authorization';
+import { Security } from '#decorators/methods/options/Security';
 
 // Bearer Token Authentication Frame
+
+@Authorization('user-token-12345')
 @Get({
   host: 'http://api.example.com/user/:id',
   security: new BearerTokenProvider(),
-  authorization: 'user-token-12345',
 })
 class UserProfileFrame extends JinFrame {
   @Param()
@@ -29,10 +32,10 @@ class UserProfileFrame extends JinFrame {
 }
 
 // API Key in Header Authentication Frame
+@Security(new ApiKeyProvider('api-key', 'X-API-Key', 'header'))
+@Authorization('secret-api-key-value')
 @Get({
   host: 'http://api.example.com/data',
-  security: new ApiKeyProvider('api-key', 'X-API-Key', 'header'),
-  authorization: 'secret-api-key-value',
 })
 class DataFrame extends JinFrame {
   @Query()
@@ -77,18 +80,18 @@ class AdminUserFrame extends JinFrame {
 }
 
 // OAuth2 Authentication Frame
+@Security(new OAuth2Provider('oauth2', 'Bearer'))
+@Authorization({ accessToken: 'oauth-access-token-xyz', tokenType: 'Bearer' })
 @Get({
   host: 'http://api.example.com/oauth/profile',
-  security: new OAuth2Provider('oauth2', 'Bearer'),
-  authorization: { accessToken: 'oauth-access-token-xyz', tokenType: 'Bearer' },
 })
 class OAuthProfileFrame extends JinFrame {}
 
 // Multiple Security Providers Frame
+@Security([new BearerTokenProvider(), new ApiKeyProvider('client-id', 'X-Client-ID', 'header')])
+@Authorization('multi-auth-token')
 @Get({
   host: 'http://api.example.com/secure',
-  security: [new BearerTokenProvider(), new ApiKeyProvider('client-id', 'X-Client-ID', 'header')],
-  authorization: 'multi-auth-token',
 })
 class MultiSecurityFrame extends JinFrame {}
 

--- a/packages/jin-frame/src/decorators/methods/handlers/REQUEST_AUTHORIZATION_DECORATOR.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/REQUEST_AUTHORIZATION_DECORATOR.ts
@@ -1,0 +1,1 @@
+export const REQUEST_AUTHORIZATION_DECORATOR = Symbol('jinframe:class-request-authorization-decorator');

--- a/packages/jin-frame/src/decorators/methods/handlers/REQUEST_SECURITY_DECORATOR.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/REQUEST_SECURITY_DECORATOR.ts
@@ -1,0 +1,1 @@
+export const REQUEST_SECURITY_DECORATOR = Symbol('jinframe:class-request-security-decorator');

--- a/packages/jin-frame/src/decorators/methods/handlers/getAllMethodMetaInherited.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/getAllMethodMetaInherited.ts
@@ -1,27 +1,34 @@
 import { REQUEST_METHOD_DECORATOR } from '#decorators/methods/handlers/REQUEST_METHOD_DECORATOR';
 import { REQUEST_RETRY_DECORATOR } from '#decorators/methods/handlers/REQUEST_RETRY_DECORATOR';
 import { REQUEST_TIMEOUT_DECORATOR } from '#decorators/methods/handlers/REQUEST_TIMEOUT_DECORATOR';
-import type { TMethodEntry } from '#interfaces/options/TMethodEntry';
-import type { AbstractConstructor, Constructor } from 'type-fest';
-import type { Milliseconds } from 'axios';
-import type { IFrameRetry } from '#interfaces/options/IFrameRetry';
-import type { BaseValidator } from '#validators/BaseValidator';
-import 'reflect-metadata';
 import { REQUEST_VALIDATOR_DECORATOR } from '#decorators/methods/handlers/REQUEST_VALIDATOR_DECORATOR';
 import { REQUEST_DEDUPE_DECORATOR } from '#decorators/methods/handlers/REQUEST_DEDUPE_DECORATOR';
+import { REQUEST_AUTHORIZATION_DECORATOR } from '#decorators/methods/handlers/REQUEST_AUTHORIZATION_DECORATOR';
+import { REQUEST_SECURITY_DECORATOR } from '#decorators/methods/handlers/REQUEST_SECURITY_DECORATOR';
+import type { TMethodEntry } from '#interfaces/options/TMethodEntry';
+import type { AbstractConstructor, Constructor } from 'type-fest';
+import type { IFrameRetry } from '#interfaces/options/IFrameRetry';
+import type { BaseValidator } from '#validators/BaseValidator';
+import type { TMilliseconds } from '#interfaces/options/TMilliseconds';
+import type { IFrameOption } from '#interfaces/options/IFrameOption';
+import 'reflect-metadata';
 
 export function getAllRequestMetaInherited(ctor: AbstractConstructor<unknown> | Constructor<unknown>): {
   methods: readonly TMethodEntry[];
   retries: readonly IFrameRetry[];
-  timeouts: readonly Milliseconds[];
+  timeouts: readonly TMilliseconds[];
   validators: readonly BaseValidator[];
   dedupes: readonly boolean[];
+  authorizations: readonly IFrameOption['authorization'][];
+  securities: readonly IFrameOption['security'][];
 } {
   const methods: TMethodEntry[] = [];
   const retries: IFrameRetry[] = [];
-  const timeouts: Milliseconds[] = [];
+  const timeouts: TMilliseconds[] = [];
   const validators: BaseValidator[] = [];
   const dedupes: boolean[] = [];
+  const authorizations: IFrameOption['authorization'][] = [];
+  const securities: IFrameOption['security'][] = [];
 
   // eslint-disable-next-line no-restricted-syntax
   for (
@@ -31,16 +38,22 @@ export function getAllRequestMetaInherited(ctor: AbstractConstructor<unknown> | 
   ) {
     const method = (Reflect.getOwnMetadata(REQUEST_METHOD_DECORATOR, c) as TMethodEntry[] | undefined) ?? [];
     const retry = (Reflect.getOwnMetadata(REQUEST_RETRY_DECORATOR, c) as IFrameRetry[] | undefined) ?? [];
-    const timeout = (Reflect.getOwnMetadata(REQUEST_TIMEOUT_DECORATOR, c) as Milliseconds[] | undefined) ?? [];
+    const timeout = (Reflect.getOwnMetadata(REQUEST_TIMEOUT_DECORATOR, c) as TMilliseconds[] | undefined) ?? [];
     const validator = (Reflect.getOwnMetadata(REQUEST_VALIDATOR_DECORATOR, c) as BaseValidator[] | undefined) ?? [];
     const dedupe = (Reflect.getOwnMetadata(REQUEST_DEDUPE_DECORATOR, c) as boolean[] | undefined) ?? [];
+    const authorization =
+      (Reflect.getOwnMetadata(REQUEST_AUTHORIZATION_DECORATOR, c) as IFrameOption['authorization'][] | undefined) ?? [];
+    const security =
+      (Reflect.getOwnMetadata(REQUEST_SECURITY_DECORATOR, c) as IFrameOption['security'][] | undefined) ?? [];
 
     methods.push(...method);
     retries.push(...retry);
     timeouts.push(...timeout);
     validators.push(...validator);
     dedupes.push(...dedupe);
+    authorizations.push(...authorization);
+    securities.push(...security);
   }
 
-  return { methods, retries, timeouts, validators, dedupes };
+  return { methods, retries, timeouts, validators, dedupes, authorizations, securities };
 }

--- a/packages/jin-frame/src/decorators/methods/handlers/getAllRequestMetaInherited.test.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/getAllRequestMetaInherited.test.ts
@@ -6,15 +6,24 @@ import { Patch } from '#decorators/methods/Patch';
 import { Timeout } from '#decorators/methods/options/Timeout';
 import { Retry } from '#decorators/methods/options/Retry';
 import { Validator } from '#decorators/methods/options/Validator';
+import { Security } from '#decorators/methods/options/Security';
+import { Authorization } from '#decorators/methods/options/Authorization';
 import { BaseValidator } from '#validators/BaseValidator';
 import { Put } from '#decorators/methods/Put';
+import { BearerTokenProvider } from '#providers/security/BearerTokenProvider';
+import { ApiKeyProvider } from '#providers/security/ApiKeyProvider';
+import { BasicAuthProvider } from '#providers/security/BasicAuthProvider';
 
+@Security(new BearerTokenProvider('base-auth'))
+@Authorization('Bearer base-token')
 @Get({ host: 'http://some.host.com' })
 class GetAllRequestMetaInheritedTest001 {}
 
+@Authorization({ apiKey: 'post-api-key' })
 @Post({ path: 'some/path' })
 class GetAllRequestMetaInheritedTest002 extends GetAllRequestMetaInheritedTest001 {}
 
+@Security(new ApiKeyProvider('patch-auth', 'X-API-Key', 'header'))
 @Timeout(1000)
 @Patch({
   contentType: 'custom-content-type',
@@ -27,6 +36,8 @@ class GetAllRequestMetaInheritedTest003 extends GetAllRequestMetaInheritedTest00
 @Put({ authoriztion: 'i-am-authorization-key' })
 class GetAllRequestMetaInheritedTest004 extends GetAllRequestMetaInheritedTest003 {}
 
+@Security([new BasicAuthProvider('final-auth'), new BearerTokenProvider('final-bearer')])
+@Authorization({ sessionId: 'final-session', userId: 'final-user' })
 @Timeout(2000)
 @Validator(new BaseValidator({ type: 'exception' }))
 @Get({ path: 'overwrite/double/path', authoriztion: 'i-am-authorization-key' })
@@ -126,6 +137,108 @@ describe('getAllRequestMetaInherited', () => {
       retries: [{ max: 2, interval: 500 }],
       timeouts: [2000, 3000, 1000],
       validators: [new BaseValidator({ type: 'exception' })],
+      dedupes: [],
+      securities: [
+        [new BasicAuthProvider('final-auth'), new BearerTokenProvider('final-bearer')],
+        new ApiKeyProvider('patch-auth', 'X-API-Key', 'header'),
+        new BearerTokenProvider('base-auth'),
+      ],
+      authorizations: [
+        { sessionId: 'final-session', userId: 'final-user' },
+        { apiKey: 'post-api-key' },
+        'Bearer base-token',
+      ],
     });
+  });
+
+  it('should handle Security and Authorization inheritance correctly', () => {
+    // Test inheritance hierarchy for Security and Authorization
+    @Security(new BearerTokenProvider('grandparent-auth'))
+    @Authorization('Bearer grandparent-token')
+    @Get({ host: 'https://api.example.com' })
+    class GrandParentClass {}
+
+    @Security(new ApiKeyProvider('parent-auth', 'X-API-Key', 'header'))
+    @Authorization({ apiKey: 'parent-key', scope: 'read' })
+    @Post({ path: '/api/v1' })
+    class ParentClass extends GrandParentClass {}
+
+    @Security([new BasicAuthProvider('child-auth'), new BearerTokenProvider('child-bearer')])
+    @Authorization({ sessionId: 'child-session', permissions: ['read', 'write'] })
+    @Put({ path: '/api/v2/resource' })
+    class ChildClass extends ParentClass {}
+
+    const metas = getAllRequestMetaInherited(ChildClass);
+
+    expect(metas.securities).toEqual([
+      [new BasicAuthProvider('child-auth'), new BearerTokenProvider('child-bearer')],
+      new ApiKeyProvider('parent-auth', 'X-API-Key', 'header'),
+      new BearerTokenProvider('grandparent-auth'),
+    ]);
+
+    expect(metas.authorizations).toEqual([
+      { sessionId: 'child-session', permissions: ['read', 'write'] },
+      { apiKey: 'parent-key', scope: 'read' },
+      'Bearer grandparent-token',
+    ]);
+
+    expect(metas.methods).toHaveLength(3);
+    expect(metas.methods.at(0)?.option.method).toBe('PUT');
+    expect(metas.methods.at(1)?.option.method).toBe('POST');
+    expect(metas.methods.at(2)?.option.method).toBe('GET');
+  });
+
+  it('should handle Security and Authorization with mixed decorators', () => {
+    @Security(new BearerTokenProvider('base-security'))
+    @Get({ host: 'https://base.example.com' })
+    class BaseClass {}
+
+    @Authorization({ token: 'middle-auth' })
+    @Timeout(5000)
+    @Post({ path: '/middle' })
+    class MiddleClass extends BaseClass {}
+
+    @Security([new ApiKeyProvider('final-key', 'X-Key', 'query'), new BasicAuthProvider('final-basic')])
+    @Authorization('Bearer final-token')
+    @Retry({ max: 3, interval: 1000 })
+    @Patch({ path: '/final' })
+    class FinalClass extends MiddleClass {}
+
+    const metas = getAllRequestMetaInherited(FinalClass);
+
+    expect(metas.securities).toEqual([
+      [new ApiKeyProvider('final-key', 'X-Key', 'query'), new BasicAuthProvider('final-basic')],
+      new BearerTokenProvider('base-security'),
+    ]);
+
+    expect(metas.authorizations).toEqual(['Bearer final-token', { token: 'middle-auth' }]);
+
+    expect(metas.retries).toEqual([{ max: 3, interval: 1000 }]);
+    expect(metas.timeouts).toEqual([5000]);
+  });
+
+  it('should handle empty Security and Authorization arrays correctly', () => {
+    @Get({ host: 'https://no-auth.example.com' })
+    class NoAuthClass {}
+
+    @Security(new BearerTokenProvider('only-security'))
+    @Post({ path: '/only-security' })
+    class OnlySecurityClass extends NoAuthClass {}
+
+    @Authorization('Bearer only-auth')
+    @Put({ path: '/only-auth' })
+    class OnlyAuthClass extends OnlySecurityClass {}
+
+    const noAuthMetas = getAllRequestMetaInherited(NoAuthClass);
+    expect(noAuthMetas.securities).toEqual([]);
+    expect(noAuthMetas.authorizations).toEqual([]);
+
+    const onlySecurityMetas = getAllRequestMetaInherited(OnlySecurityClass);
+    expect(onlySecurityMetas.securities).toEqual([new BearerTokenProvider('only-security')]);
+    expect(onlySecurityMetas.authorizations).toEqual([]);
+
+    const onlyAuthMetas = getAllRequestMetaInherited(OnlyAuthClass);
+    expect(onlyAuthMetas.securities).toEqual([new BearerTokenProvider('only-security')]);
+    expect(onlyAuthMetas.authorizations).toEqual(['Bearer only-auth']);
   });
 });

--- a/packages/jin-frame/src/decorators/methods/handlers/getRequestMeta.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/getRequestMeta.ts
@@ -29,6 +29,8 @@ export function getRequestMeta(ctor: AbstractConstructor<unknown> | Constructor<
   const timeouts = [...metas.timeouts].reverse();
   const validators = [...metas.validators].reverse();
   const dedupes = [...metas.dedupes].reverse();
+  const authorizations = [...metas.authorizations].reverse();
+  const securities = [...metas.securities].reverse();
 
   const mergedOption = methods.reduce<IFrameOption>(
     (merged, meta) => mergeFrameOption(merged, meta.option),
@@ -46,6 +48,8 @@ export function getRequestMeta(ctor: AbstractConstructor<unknown> | Constructor<
   const mergedValidator = validators.at(-1);
   const mergedTimeout = timeouts.at(-1);
   const mergedDeduped = dedupes.at(-1);
+  const mergedAuthorization = authorizations.at(-1);
+  const mergedSecurity = securities.at(-1);
 
   if (mergedRetry != null) {
     mergedOption.retry = mergedRetry;
@@ -61,6 +65,14 @@ export function getRequestMeta(ctor: AbstractConstructor<unknown> | Constructor<
 
   if (mergedDeduped != null) {
     mergedOption.dedupe = mergedDeduped;
+  }
+
+  if (mergedAuthorization != null) {
+    mergedOption.authorization = mergedAuthorization;
+  }
+
+  if (mergedSecurity != null) {
+    mergedOption.security = mergedSecurity;
   }
 
   if (Object.keys(mergedOption).length <= 0) {

--- a/packages/jin-frame/src/decorators/methods/options/Authorization.test.ts
+++ b/packages/jin-frame/src/decorators/methods/options/Authorization.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { getRequestMeta } from '#decorators/methods/handlers/getRequestMeta';
+import { Authorization } from '#decorators/methods/options/Authorization';
+
+describe('Authorization', () => {
+  it('should set authorization metadata correctly when Authorization decorator applied with string token', () => {
+    class TestClass {}
+
+    const authToken = 'Bearer my-secret-token';
+    const handle = Authorization(authToken);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(meta.option.authorization).toEqual(authToken);
+  });
+
+  it('should set authorization metadata correctly when Authorization decorator applied with object data', () => {
+    class TestClass {}
+
+    const authData = {
+      apiKey: 'secret-api-key',
+      userId: 'user123',
+      sessionId: 'session456',
+    };
+    const handle = Authorization(authData);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(meta.option.authorization).toEqual(authData);
+  });
+
+  it('should support complex authorization data structures', () => {
+    class TestClass {}
+
+    const authData = {
+      bearerToken: 'Bearer token123',
+      apiKey: 'api-key-456',
+      sessionId: 'session-789',
+    };
+
+    const handle = Authorization(authData);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(meta.option.authorization).toEqual(authData);
+  });
+
+  it('should freeze authorization option to prevent mutation', () => {
+    class TestClass {}
+
+    const authData = { apiKey: 'secret-key', userId: 'user123' };
+    const handle = Authorization(authData);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(Object.isFrozen(meta.option.authorization)).toBe(true);
+  });
+
+  it('should handle complex nested authorization data', () => {
+    class TestClass {}
+
+    const complexAuth = {
+      oauth: {
+        accessToken: 'access-token-123',
+        refreshToken: 'refresh-token-456',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+      },
+      apiKeys: ['key1', 'key2', 'key3'],
+      metadata: {
+        userId: 'user123',
+        scopes: ['read', 'write', 'admin'],
+      },
+    };
+
+    const handle = Authorization(complexAuth);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(meta.option.authorization).toEqual(complexAuth);
+    expect(Object.isFrozen(meta.option.authorization)).toBe(true);
+  });
+
+  it('should override parent class authorization in inheritance hierarchy', () => {
+    class ParentClass {}
+    class ChildClass extends ParentClass {}
+
+    const parentAuth = 'Bearer parent-token';
+    const childAuth = { apiKey: 'child-key' };
+
+    const parentHandle = Authorization(parentAuth);
+    const childHandle = Authorization(childAuth);
+
+    parentHandle(ParentClass);
+    childHandle(ChildClass);
+
+    const parentMeta = getRequestMeta(ParentClass);
+    const childMeta = getRequestMeta(ChildClass);
+
+    expect(parentMeta.option.authorization).toEqual(parentAuth);
+    // Child should override parent's authorization
+    expect(childMeta.option.authorization).toEqual(childAuth);
+  });
+});

--- a/packages/jin-frame/src/decorators/methods/options/Authorization.ts
+++ b/packages/jin-frame/src/decorators/methods/options/Authorization.ts
@@ -1,0 +1,15 @@
+import { REQUEST_AUTHORIZATION_DECORATOR } from '#decorators/methods/handlers/REQUEST_AUTHORIZATION_DECORATOR';
+import type { IFrameOption } from '#interfaces/options/IFrameOption';
+import 'reflect-metadata';
+
+export function Authorization(_option: IFrameOption['authorization']) {
+  return function authorizationHandle(target: object): void {
+    const prev =
+      (Reflect.getOwnMetadata(REQUEST_AUTHORIZATION_DECORATOR, target) as
+        | IFrameOption['authorization'][]
+        | undefined) ?? [];
+    const option = Object.freeze(_option);
+
+    Reflect.defineMetadata(REQUEST_AUTHORIZATION_DECORATOR, [...prev, option], target);
+  };
+}

--- a/packages/jin-frame/src/decorators/methods/options/Security.test.ts
+++ b/packages/jin-frame/src/decorators/methods/options/Security.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { getRequestMeta } from '#decorators/methods/handlers/getRequestMeta';
+import { Security } from '#decorators/methods/options/Security';
+import { BearerTokenProvider } from '#providers/security/BearerTokenProvider';
+import { ApiKeyProvider } from '#providers/security/ApiKeyProvider';
+import { BasicAuthProvider } from '#providers/security/BasicAuthProvider';
+
+describe('Security', () => {
+  it('should set security metadata correctly when Security decorator applied with single provider', () => {
+    class TestClass {}
+
+    const provider = new BearerTokenProvider('auth-bearer');
+    const handle = Security(provider);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(meta.option.security).toEqual(provider);
+  });
+
+  it('should set security metadata correctly when Security decorator applied with multiple providers', () => {
+    class TestClass {}
+
+    const providers = [new BearerTokenProvider('auth-bearer'), new ApiKeyProvider('api-key', 'X-API-Key', 'header')];
+    const handle = Security(providers);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(meta.option.security).toEqual(providers);
+  });
+
+  it('should support multiple security providers via array parameter', () => {
+    class TestClass {}
+
+    const provider1 = new BearerTokenProvider('auth-bearer');
+    const provider2 = new ApiKeyProvider('api-key', 'X-API-Key', 'header');
+    const provider3 = new BasicAuthProvider('basic-auth');
+
+    // Proper way to use multiple security providers is via array
+    const handle = Security([provider1, provider2, provider3]);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(meta.option.security).toEqual([provider1, provider2, provider3]);
+  });
+
+  it('should freeze security provider option to prevent mutation', () => {
+    class TestClass {}
+
+    const provider = new BearerTokenProvider('auth-bearer');
+    const handle = Security(provider);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(Object.isFrozen(meta.option.security)).toBe(true);
+  });
+
+  it('should handle array of providers and freeze the array', () => {
+    class TestClass {}
+
+    const providers = [new BearerTokenProvider('auth-bearer'), new ApiKeyProvider('api-key', 'X-API-Key', 'header')];
+    const handle = Security(providers);
+    handle(TestClass);
+
+    const meta = getRequestMeta(TestClass);
+
+    expect(Object.isFrozen(meta.option.security)).toBe(true);
+  });
+
+  it('should override parent class security in inheritance hierarchy', () => {
+    class ParentClass {}
+    class ChildClass extends ParentClass {}
+
+    const parentProvider = new BearerTokenProvider('parent-auth');
+    const childProvider = new ApiKeyProvider('child-auth', 'X-API-Key', 'header');
+
+    const parentHandle = Security(parentProvider);
+    const childHandle = Security(childProvider);
+
+    parentHandle(ParentClass);
+    childHandle(ChildClass);
+
+    const parentMeta = getRequestMeta(ParentClass);
+    const childMeta = getRequestMeta(ChildClass);
+
+    expect(parentMeta.option.security).toEqual(parentProvider);
+    // Child should override parent's security
+    expect(childMeta.option.security).toEqual(childProvider);
+  });
+});

--- a/packages/jin-frame/src/decorators/methods/options/Security.ts
+++ b/packages/jin-frame/src/decorators/methods/options/Security.ts
@@ -1,0 +1,12 @@
+import { REQUEST_SECURITY_DECORATOR } from '#decorators/methods/handlers/REQUEST_SECURITY_DECORATOR';
+import type { IFrameOption } from '#interfaces/options/IFrameOption';
+import 'reflect-metadata';
+
+export function Security(_option: IFrameOption['security']) {
+  return function securityHandle(target: object): void {
+    const prev = (Reflect.getOwnMetadata(REQUEST_SECURITY_DECORATOR, target) as IFrameOption['security'][]) ?? [];
+    const option = Object.freeze(_option);
+
+    Reflect.defineMetadata(REQUEST_SECURITY_DECORATOR, [...prev, option], target);
+  };
+}


### PR DESCRIPTION
- Add Security decorator for declarative security provider configuration
- Add Authorization decorator for authentication data management
- Integrate decorators into metadata inheritance system via getAllRequestMetaInherited
- Update getRequestMeta to handle security and authorization metadata
- Create comprehensive test suites covering:
  - Single and multiple security providers
  - Complex authorization data structures
  - Inheritance hierarchy behavior
  - Integration with existing decorators (Timeout, Retry, Validator)
  - Edge cases and empty configurations
- Migrate security.test.ts from inline options to decorator pattern
- Ensure proper metadata freezing for immutability
- Support both individual and array-based security providers

🤖 Generated with [Claude Code](https://claude.ai/code)