### PR TITLE
docs: add comments to builder type patterns and fix typedoc tsconfig

### DIFF
--- a/packages/jin-frame/.configs/typedoc.json
+++ b/packages/jin-frame/.configs/typedoc.json
@@ -2,7 +2,7 @@
   "entryPoints": [
     "../src"
   ],
-  "tsconfig": "../tsconfig.json",
+  "tsconfig": "../tsconfig.prod.json",
   "entryPointStrategy": "expand",
   "plugin": ["typedoc-plugin-markdown", "typedoc-vitepress-theme"],
   "out": "../docs/api",

--- a/packages/jin-frame/src/tools/type-utilities/BuilderFor.ts
+++ b/packages/jin-frame/src/tools/type-utilities/BuilderFor.ts
@@ -1,6 +1,39 @@
 import type { PublicFieldsOf } from '#tools/type-utilities/FieldsOf';
 import type { ConstructorFunction } from '#tools/type-utilities/ConstructorFunction';
 
+/**
+ * Builder interface for constructing JinFrame instances with compile-time field tracking.
+ *
+ * `TSet` accumulates the union of field keys explicitly provided via `set()` or `from()`.
+ * `build()` is only callable when `TSet` covers every public field key, enforcing that
+ * all fields are assigned before the instance is created.
+ *
+ * **Known DX limitation with `getDefaultValues()`**
+ *
+ * Fields supplied by `getDefaultValues()` must be declared optional (`field?: T`) so that
+ * `build()` does not require them to be explicitly set through the builder.
+ * The trade-off is that TypeScript then widens their access type to `T | undefined`,
+ * requiring null checks even though the value is always present at runtime.
+ * Fully resolving this would require the type system to infer which fields are covered by
+ * `getDefaultValues()` — currently not achievable without modifying `AbstractJinFrame`.
+ *
+ * ---
+ *
+ * JinFrame 인스턴스를 생성하기 위한 빌더 인터페이스로, 컴파일 타임 필드 추적을 제공합니다.
+ *
+ * `TSet`은 `set()` 또는 `from()`으로 명시적으로 제공된 필드 키의 유니온을 누적합니다.
+ * `build()`는 `TSet`이 모든 공개 필드 키를 포함할 때만 호출 가능하여,
+ * 인스턴스 생성 전에 모든 필드가 할당되었음을 타입 수준에서 강제합니다.
+ *
+ * **`getDefaultValues()`와의 알려진 DX 한계**
+ *
+ * `getDefaultValues()`로 제공되는 필드는 빌더에서 명시적 설정 없이도 `build()`를
+ * 호출할 수 있도록 optional(`field?: T`)로 선언해야 합니다.
+ * 그 결과 해당 필드의 접근 타입이 `T | undefined`로 넓혀지므로, 런타임에 값이 항상
+ * 존재함에도 불구하고 null 체크가 필요해지는 DX 저하가 발생합니다.
+ * 완전한 해결을 위해서는 `getDefaultValues()`가 커버하는 필드를 타입 시스템이
+ * 추론해야 하며, 현재는 `AbstractJinFrame` 수정 없이는 불가능합니다.
+ */
 export interface BuilderFor<
   C extends ConstructorFunction<unknown>,
   TSet extends keyof PublicFieldsOf<InstanceType<C>> = never,
@@ -14,5 +47,13 @@ export interface BuilderFor<
   ) => BuilderFor<C, TSet | (keyof V & keyof PublicFieldsOf<InstanceType<C>>)>;
   auto: () => BuilderFor<C, TSet | keyof PublicFieldsOf<InstanceType<C>>>;
   get: () => Readonly<Partial<PublicFieldsOf<InstanceType<C>>>>;
+  // Tuple comparison [keyof ...] extends [TSet] is intentional: a plain `A extends B`
+  // distributes over unions, which would allow partial matches. Wrapping in a tuple
+  // forces a holistic check — build() becomes callable only when TSet contains every
+  // public field key.
+  //
+  // 튜플 비교 [keyof ...] extends [TSet]는 의도된 패턴입니다. 단순 `A extends B`는
+  // 유니온에 대해 분산되어 부분 일치를 허용하므로, 튜플로 감싸 전체 검사를 강제합니다.
+  // TSet이 모든 공개 필드 키를 포함할 때만 build()가 호출 가능해집니다.
   build: [keyof PublicFieldsOf<InstanceType<C>>] extends [TSet] ? () => InstanceType<C> : never;
 }

--- a/packages/jin-frame/src/tools/type-utilities/FieldsOf.ts
+++ b/packages/jin-frame/src/tools/type-utilities/FieldsOf.ts
@@ -1,12 +1,26 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFn = (...a: any[]) => unknown;
 
+// Extracts all keys whose value type includes a function signature.
+// Used to distinguish method members from plain data properties.
+// 값 타입에 함수 시그니처가 포함된 모든 키를 추출합니다.
+// 메서드 멤버와 일반 데이터 프로퍼티를 구분하는 데 사용됩니다.
 type FunctionKeys<T> = { [K in keyof T]-?: Extract<T[K], AnyFn> extends never ? never : K }[keyof T];
 
+// Strips all method keys from T, leaving only data properties.
+// T에서 모든 메서드 키를 제거하고 데이터 프로퍼티만 남깁니다.
 type NonFunctionProps<T> = Omit<T, FunctionKeys<T>>;
 
+// Readonly view of all data properties (methods excluded).
+// 모든 데이터 프로퍼티(메서드 제외)의 읽기 전용 뷰입니다.
 export type FieldsOf<T> = Readonly<NonFunctionProps<T>>;
 
+// Like FieldsOf but additionally strips keys prefixed with '_'.
+// The '_' prefix is the project convention for internal/protected fields
+// that should not be part of the public builder or of() API surface.
+// FieldsOf와 유사하지만 '_'로 시작하는 키도 추가로 제거합니다.
+// '_' 접두사는 빌더 또는 of() API에 노출되지 않아야 하는
+// 내부/보호 필드에 대한 프로젝트 컨벤션입니다.
 export type PublicFieldsOf<T> = {
   [K in keyof NonFunctionProps<T> as K extends `_${string}` ? never : K]: NonFunctionProps<T>[K];
 };


### PR DESCRIPTION
## Summary

- Add JSDoc comments (English → Korean) to `BuilderFor` explaining the `TSet` field-tracking pattern, the tuple comparison trick, and the known DX limitation with `getDefaultValues()`
- Add inline comments to `FieldsOf` explaining each utility type (`FunctionKeys`, `NonFunctionProps`, `FieldsOf`, `PublicFieldsOf` and its `_`-prefix stripping convention)
- Switch TypeDoc to use `tsconfig.prod.json` so test files are excluded from type-checking during documentation generation

## Test plan

- [ ] `pnpm --filter jin-frame run build:ne` passes (no type errors)
- [ ] `pnpm --filter jin-frame run docs:typedoc` builds without errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)