### PR TITLE
fix(jin-frame): v5.0.2 — safeParse plain-text response bug fix

### DIFF
--- a/packages/jin-frame/package.json
+++ b/packages/jin-frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jin-frame",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Reusable HTTP API request definition library",
   "packageManager": "pnpm@10.16.0",
   "scripts": {

--- a/packages/jin-frame/src/tools/json/safeParse.test.ts
+++ b/packages/jin-frame/src/tools/json/safeParse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { safeParse } from '#tools/json/safeParse';
+
+describe('safeParse', () => {
+  it('should parse JSON object when valid JSON string provided', () => {
+    expect(safeParse('{"key":"value"}')).toEqual({ key: 'value' });
+  });
+
+  it('should parse JSON array when valid JSON array string provided', () => {
+    expect(safeParse('[1,2,3]')).toEqual([1, 2, 3]);
+  });
+
+  it('should parse boolean true when JSON boolean string provided', () => {
+    expect(safeParse('true')).toBe(true);
+  });
+
+  it('should parse boolean false when JSON boolean string provided', () => {
+    expect(safeParse('false')).toBe(false);
+  });
+
+  it('should parse number when JSON number string provided', () => {
+    expect(safeParse('42')).toBe(42);
+  });
+
+  it('should parse null when JSON null string provided', () => {
+    expect(safeParse('null')).toBeNull();
+  });
+
+  it('should return raw string when plain non-JSON string provided', () => {
+    expect(safeParse('hello')).toBe('hello');
+  });
+
+  it('should return raw string when API returns plain text response', () => {
+    expect(safeParse('plain text response')).toBe('plain text response');
+  });
+});

--- a/packages/jin-frame/src/tools/json/safeParse.ts
+++ b/packages/jin-frame/src/tools/json/safeParse.ts
@@ -2,6 +2,7 @@ export function safeParse<T = unknown>(value: string): T | undefined {
   try {
     return JSON.parse(value) as T;
   } catch {
-    return undefined;
+    // Return raw string for plain-text responses (e.g. API returns "hello" without JSON encoding)
+    return value as unknown as T;
   }
 }


### PR DESCRIPTION
## Summary

- **`safeParse` 버그 수정**: API가 plain string(`hello` 등 JSON-encode되지 않은 문자열)을 반환할 때 `JSON.parse`가 실패하여 `undefined`가 데이터로 설정되던 문제 수정
  - 수정 전: parse 실패 시 `undefined` 반환
  - 수정 후: parse 실패 시 원본 문자열 반환 (boolean/number는 `JSON.parse`가 정상 처리하므로 영향 없음)
- **`safeParse.test.ts`** 신규 추가: JSON object, array, boolean, number, null, plain string 8가지 케이스 커버

## Test plan

- [x] 전체 테스트 480개 통과 (`pnpm --filter jin-frame test`)
- [x] `safeParse` 단위 테스트 8개 모두 통과

🤖 Generated with [Claude Code](https://claude.ai/claude-code)