### PR TITLE
feat(jin-frame): validateStatus in FrameOption, safeParse fix, PUT/PATCH multipart, comment translations

### DIFF
--- a/packages/jin-frame/package.json
+++ b/packages/jin-frame/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jin-frame",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Reusable HTTP API request definition library",
   "packageManager": "pnpm@10.16.0",
   "scripts": {

--- a/packages/jin-frame/src/decorators/getFrameOption.ts
+++ b/packages/jin-frame/src/decorators/getFrameOption.ts
@@ -13,6 +13,7 @@ export function getFrameOption(method: Method, option?: Partial<Omit<FrameOption
     retry: option?.retry,
     timeout: option?.timeout,
     validators: option?.validators,
+    validateStatus: option?.validateStatus,
     dedupe: option?.dedupe,
     security: option?.security,
     authorization: option?.authorization,

--- a/packages/jin-frame/src/decorators/methods/handlers/getRequestMeta.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/getRequestMeta.ts
@@ -7,18 +7,21 @@ import { mergeFrameOption } from '#tools/mergeFrameOption';
 import { mergeRetryOption } from '#tools/mergeRetryOption';
 
 /**
+ * Resolves and merges all method decorator metadata for a class constructor,
+ * walking the inheritance chain. When a parent and child both apply a decorator,
+ * the parent receives a higher index — child metadata takes precedence.
  *
- * 상속관계가 만들어지는 경우, 부모가 뒷번호 index를 받는다. 아래와 같은 경우
- * IamDecorateParentGetClass가 01, IamDecorateChildGetClass가 00 이다.
- *
+ * @example
+ * ```typescript
  * @Delete({ host: 'i-am-host' })
- * class IamDecorateParentGetClass {}
+ * class ParentFrame {}
  *
  * @Get({ host: 'i-am-host' })
- * class IamDecorateChildGetClass extends IamDecorateParentGetClass {}
+ * class ChildFrame extends ParentFrame {}
+ * // ParentFrame → index 01, ChildFrame → index 00
+ * ```
  *
  * @param ctor Constructor function
- * @returns
  */
 export function getRequestMeta(ctor: AbstractConstructor<unknown> | Constructor<unknown>): MethodEntry {
   const metas = getAllRequestMetaInherited(ctor);

--- a/packages/jin-frame/src/decorators/methods/handlers/pushRequestMeta.ts
+++ b/packages/jin-frame/src/decorators/methods/handlers/pushRequestMeta.ts
@@ -3,9 +3,7 @@ import type { MethodEntry } from '#interfaces/options/MethodEntry';
 import type { Constructor } from 'type-fest';
 import 'reflect-metadata';
 
-/**
- * target(생성자)에 메서드 엔트리를 누적(push) 저장
- * */
+/** Appends a method entry to the metadata stored on the given constructor target. */
 export function pushRequestMeta<T>(target: Constructor<T>, entry: MethodEntry): void {
   const prev = (Reflect.getOwnMetadata(REQUEST_METHOD_DECORATOR, target) as MethodEntry[] | undefined) ?? [];
   Reflect.defineMetadata(REQUEST_METHOD_DECORATOR, [...prev, entry], target);

--- a/packages/jin-frame/src/frames/JinFrame.test.ts
+++ b/packages/jin-frame/src/frames/JinFrame.test.ts
@@ -1375,3 +1375,52 @@ describe('Dedupe Request', () => {
     console.log(reply03.data.message);
   });
 });
+
+describe('validateStatus in FrameOption', () => {
+  @Post({
+    host: 'http://some.api.google.com/validate-status-frame',
+    validateStatus: (_ok, status) => status === 200 || status === 404,
+  })
+  class ValidateStatusFrame extends JinFrame<{ message: string }> {
+    @Body()
+    declare public readonly username: string;
+  }
+
+  const server = setupServer();
+
+  beforeEach(() => server.listen());
+  afterEach(() => {
+    server.resetHandlers();
+    server.close();
+  });
+
+  it('should treat 404 as success when validateStatus is set on FrameOption', async () => {
+    server.use(
+      http.post(
+        'http://some.api.google.com/validate-status-frame',
+        () => new HttpResponse('Not Found', { status: 404 }),
+      ),
+    );
+
+    const frame = ValidateStatusFrame.of({ username: 'ironman' });
+    const reply = await frame._execute();
+
+    expect(reply.ok).toBe(true);
+    expect(reply.status).toBe(404);
+  });
+
+  it('should allow _execute validateStatus to override FrameOption validateStatus', async () => {
+    server.use(
+      http.post(
+        'http://some.api.google.com/validate-status-frame',
+        () => new HttpResponse('Not Found', { status: 404 }),
+      ),
+    );
+
+    const frame = ValidateStatusFrame.of({ username: 'ironman' });
+
+    await expect(frame._execute({ validateStatus: (ok) => ok })).rejects.toMatchObject({
+      resp: { status: 404 },
+    });
+  });
+});

--- a/packages/jin-frame/src/frames/JinFrame.ts
+++ b/packages/jin-frame/src/frames/JinFrame.ts
@@ -104,7 +104,7 @@ export class JinFrame<Pass = unknown, Fail = Pass> extends AbstractJinFrame impl
     }
   > {
     const req = this._requestWrap(option);
-    const isValidateStatus = option?.validateStatus ?? isValidateStatusDefault;
+    const isValidateStatus = option?.validateStatus ?? this._option.validateStatus ?? isValidateStatusDefault;
 
     const jinFrameHandle = async (): Promise<
       JinPassResp<Pass> & {

--- a/packages/jin-frame/src/interfaces/options/Formatter.ts
+++ b/packages/jin-frame/src/interfaces/options/Formatter.ts
@@ -10,7 +10,8 @@ export interface Formatter {
   order?: ('string' | 'number' | 'dateTime')[];
 
   /**
-   * 오류가 발생했을 때 값을 버립니다. false를 전달하면 exception이 발생합니다
+   * When true, silently discards the value on formatter error.
+   * When false, throws an exception on error.
    */
   ignoreError?: boolean;
 

--- a/packages/jin-frame/src/interfaces/options/FrameOption.ts
+++ b/packages/jin-frame/src/interfaces/options/FrameOption.ts
@@ -7,17 +7,16 @@ import type { Milliseconds } from '#interfaces/options/Milliseconds';
 
 export interface FrameOption {
   /**
-   * host and path of API Request endpoint
+   * Base URL of the API endpoint.
    *
-   * 원한다면 protocol://host/path 전체를 host에 전달해도 정상 동작한다. 그럼에도 불구하고
-   * 굳이 host와 path를 분리한 이유는 Parent Class에 host를 설정하고 그것을 계속 상속을 받아서
-   * 사용하는 방식으로 확장하는 경우, Child Class에서는 path만 설정할 수 있어야 하기 때문에
-   * 둘을 분리해서 처리할 수도 있어야 한다.
-   * */
+   * You may pass the full `protocol://host/path` in this field alone, but separating `host`
+   * and `path` is recommended so that a parent class can define the host and child classes
+   * only override the path.
+   */
   host?: string | (() => string);
 
   /**
-   * Path prefix of API Request endpoint
+   * Path prefix of API Request endpoint.
    *
    * For example, you can set the relative path defined in the OpenAPI Spec's servers field to pathPrefix.
    * When set, this path will be prepended to the pathname when generating the Request URL.
@@ -37,37 +36,37 @@ export interface FrameOption {
    */
   pathPrefix?: string | (() => string);
 
-  /** path of API Request endpoint */
+  /** Path of the API endpoint. Supports path-parameter placeholders such as `:id`. */
   path?: string | (() => string);
 
-  /** method of API Request endpoint */
+  /** HTTP method of the endpoint. */
   method: Method;
 
-  /** content-type of API Request endpoint */
+  /** Content-Type of the request body. */
   contentType: string;
 
-  /** user agent of API Request endpoint */
+  /** User-Agent string sent with each request. */
   userAgent?: string;
 
-  /** custom object of POST Request body data */
+  /** Custom request body that bypasses decorator-based body assembly. */
   customBody?: unknown;
 
-  /** retry configuration */
+  /** Retry configuration. */
   retry?: FrameRetry;
 
-  /** timeout of the request */
+  /** Request timeout in milliseconds. */
   timeout?: Milliseconds;
 
   /**
-   * Security providers for authentication
-   * Can be a single provider or array of providers for multiple authentication schemes
-   * */
+   * Security providers for authentication.
+   * Can be a single provider or an array of providers for multiple authentication schemes.
+   */
   security?: SecurityProvider | SecurityProvider[];
 
   /**
-   * Authorization data that will be passed to security providers
-   * This data can be used by providers to generate authentication information
-   * */
+   * Authorization data passed to security providers.
+   * Used by providers to generate authentication headers or query parameters.
+   */
   authorization?: AuthorizationData;
 
   /**
@@ -78,14 +77,30 @@ export interface FrameOption {
   validators?: { pass?: BaseValidator; fail?: BaseValidator };
 
   /**
-   * 이 값을 활성화 하는 경우 동일 요청이 반복되는 경우 dedupe 처리를 합니다
+   * Determines whether a response status code is considered successful.
+   * When not provided, defaults to `response.ok` (i.e. 200–299).
+   *
+   * Setting this at the decorator level applies it as the default for all executions of the frame.
+   * A `validateStatus` passed to `_execute()` takes precedence over this value.
+   *
+   * @example
+   * ```typescript
+   * // Treat 404 as a success (e.g. idempotent DELETE)
+   * validateStatus: (ok, status) => ok || status === 404
+   * ```
+   */
+  validateStatus?: (ok: boolean, status: number) => boolean;
+
+  /**
+   * When enabled, identical concurrent requests are deduplicated — only one network call
+   * is made and the result is shared with all callers.
    */
   dedupe?: boolean;
 
   /**
    * When true, clones the raw Response before consuming the body.
-   * Allows reading reap.raw after the stream is consumed.
-   * Incurs memory overhead - use only when raw access is needed.
+   * Allows reading resp.raw after the stream is consumed.
+   * Incurs memory overhead — use only when raw access is needed.
    */
   cloneRaw?: boolean;
 
@@ -94,7 +109,7 @@ export interface FrameOption {
    *
    * Receives the raw response text and returns the parsed value.
    * Useful for handling non-standard JSON (e.g. BigInt values).
-   * If not provided, JSON.parse is used.
+   * If not provided, JSON.parse is used with a plain-string fallback.
    */
   deserialize?: (text: string) => unknown;
 }

--- a/packages/jin-frame/src/interfaces/options/FrameRetry.ts
+++ b/packages/jin-frame/src/interfaces/options/FrameRetry.ts
@@ -1,33 +1,27 @@
 export interface FrameRetry {
-  /**
-   * retry를 최대 몇 번까지 할 것인지 설정
-   *
-   * Set the maximum number of retry attempts.
-   * */
+  /** Maximum number of retry attempts. */
   max: number;
 
   /**
-   * retry를 할 때 간격(ms), retry 시도 횟수에 따라 간격을 더 길게 하고 싶을 때
+   * Returns the retry interval in milliseconds based on the attempt count and elapsed time.
+   * Use this when you want to vary the interval per attempt (e.g. exponential backoff).
    *
-   * Specify the retry interval (in ms) and increase the interval based on the number of attempts.
-   *
-   * @param retry a number of the retry
-   * @param totalDuration The total duration(ms) of all retries since the start of the API request
-   * @param eachDuration duration(ms) of a single retry attempt
-   * */
+   * @param retry Current retry attempt number
+   * @param totalDuration Total elapsed time (ms) since the first attempt
+   * @param eachDuration Duration (ms) of the most recent attempt
+   */
   getInterval?: (retry: number, totalDuration: number, eachDuration: number) => number;
 
   /**
-   * retry를 할 때 간격(ms), retry 간격을 일정하게 하고 싶을 때 사용, getInterval이 설정된 경우 무시 됨
-   *
-   * Specify a fixed retry interval (in ms). Ignored if getInterval is configured.
-   * */
+   * Fixed retry interval in milliseconds.
+   * Ignored when `getInterval` is configured.
+   */
   interval?: number;
 
   /**
-   * 기본 값은 true, retry-after 헤더를 사용하고 싶을 때 사용, interval, getInterval보다 우선 동작
-   *
-   * Specify to use retry-after header. Prioritized over interval and getInterval.
-   * */
+   * When true, honours the `Retry-After` response header as the retry delay.
+   * Takes precedence over `interval` and `getInterval`.
+   * Defaults to true.
+   */
   useRetryAfter?: boolean;
 }

--- a/packages/jin-frame/src/processors/getBodyMap.ts
+++ b/packages/jin-frame/src/processors/getBodyMap.ts
@@ -45,9 +45,9 @@ export function getBodyMap<T extends Record<string, unknown>>(
   }
 
   // ------------------------------------------------------------------------------------
-  // merge.recursive 함수는 primitive type array, user defined type array, primitive 타입을
-  // merge 할 수 없다. 그래서 objectBody로 위에 열거한 3가지 형식이 전달될 경우, 별도의 처리가 필요하다.
-  // 또한 의도적으로 위에 열거한 3가지 형식을 먼저 처리한다. 즉, 기본 자료형을 먼저 처리하는 것을 원칙으로 한다.
+  // merge.recursive cannot merge primitive arrays, user-defined type arrays, or primitives
+  // directly. When objectBody receives any of these three forms, they must be handled
+  // separately. Primitives are always processed first.
   // ------------------------------------------------------------------------------------
   // primitive type array
   const primitiveTypes = objectBodies.filter((item): item is SupportArrayType => isValidPrimitiveType(item));
@@ -56,8 +56,8 @@ export function getBodyMap<T extends Record<string, unknown>>(
     return atOrThrow(primitiveTypes, 0);
   }
 
-  // ObjectBody에서 배열은 하나만 처리할 수 있다. 그래서 ObjectBody 인데 배열이 있는 경우, 배열을 전부 합쳐서 반환한다
-  // 반면 Body는 이름으로 배열을 분리하기 때문에 여러개를 처리할 수 있다
+  // ObjectBody supports only one array entry — all arrays are flattened and merged into one.
+  // Body, by contrast, separates arrays by field name so multiple arrays can coexist.
   const customArrayTypes = objectBodies.filter((item): item is unknown[] => Array.isArray(item));
   if (customArrayTypes.length > 0) {
     return customArrayTypes.reduce<unknown[]>((merged, item) => [...merged, ...item], []);

--- a/packages/jin-frame/src/tools/slash-utils/getUrl.ts
+++ b/packages/jin-frame/src/tools/slash-utils/getUrl.ts
@@ -3,7 +3,7 @@ import { removeBothSlash } from '#tools/slash-utils/removeBothSlash';
 // 1) protocol + hostname[:port] + path (RFC 3986 scheme, path value is case-sensitive)
 const pattern1 = /^([A-Za-z][A-Za-z0-9+.-]*:\/\/)([A-Za-z0-9.-]+(:\d+)?)(\/.*)?$/i;
 
-// 2) hostname + path (hostname은 TLD 포함, ignore case / path는 case-sensitive)
+// 2) hostname + path (hostname includes TLD, case-insensitive / path is case-sensitive)
 const pattern2 = /^([A-Za-z0-9-]+\.[A-Za-z]{2,})(\/.*)?$/i;
 
 // 3) only path (case-sensitive)

--- a/packages/jin-frame/src/tools/type-utilities/BuilderFor.ts
+++ b/packages/jin-frame/src/tools/type-utilities/BuilderFor.ts
@@ -16,23 +16,6 @@ import type { ConstructorFunction } from '#tools/type-utilities/ConstructorFunct
  * requiring null checks even though the value is always present at runtime.
  * Fully resolving this would require the type system to infer which fields are covered by
  * `getDefaultValues()` — currently not achievable without modifying `AbstractJinFrame`.
- *
- * ---
- *
- * JinFrame 인스턴스를 생성하기 위한 빌더 인터페이스로, 컴파일 타임 필드 추적을 제공합니다.
- *
- * `TSet`은 `set()` 또는 `from()`으로 명시적으로 제공된 필드 키의 유니온을 누적합니다.
- * `build()`는 `TSet`이 모든 공개 필드 키를 포함할 때만 호출 가능하여,
- * 인스턴스 생성 전에 모든 필드가 할당되었음을 타입 수준에서 강제합니다.
- *
- * **`getDefaultValues()`와의 알려진 DX 한계**
- *
- * `getDefaultValues()`로 제공되는 필드는 빌더에서 명시적 설정 없이도 `build()`를
- * 호출할 수 있도록 optional(`field?: T`)로 선언해야 합니다.
- * 그 결과 해당 필드의 접근 타입이 `T | undefined`로 넓혀지므로, 런타임에 값이 항상
- * 존재함에도 불구하고 null 체크가 필요해지는 DX 저하가 발생합니다.
- * 완전한 해결을 위해서는 `getDefaultValues()`가 커버하는 필드를 타입 시스템이
- * 추론해야 하며, 현재는 `AbstractJinFrame` 수정 없이는 불가능합니다.
  */
 export interface BuilderFor<
   C extends ConstructorFunction<unknown>,
@@ -51,9 +34,5 @@ export interface BuilderFor<
   // distributes over unions, which would allow partial matches. Wrapping in a tuple
   // forces a holistic check — build() becomes callable only when TSet contains every
   // public field key.
-  //
-  // 튜플 비교 [keyof ...] extends [TSet]는 의도된 패턴입니다. 단순 `A extends B`는
-  // 유니온에 대해 분산되어 부분 일치를 허용하므로, 튜플로 감싸 전체 검사를 강제합니다.
-  // TSet이 모든 공개 필드 키를 포함할 때만 build()가 호출 가능해집니다.
   build: [keyof PublicFieldsOf<InstanceType<C>>] extends [TSet] ? () => InstanceType<C> : never;
 }

--- a/packages/jin-frame/src/tools/type-utilities/FieldsOf.ts
+++ b/packages/jin-frame/src/tools/type-utilities/FieldsOf.ts
@@ -3,24 +3,17 @@ type AnyFn = (...a: any[]) => unknown;
 
 // Extracts all keys whose value type includes a function signature.
 // Used to distinguish method members from plain data properties.
-// 값 타입에 함수 시그니처가 포함된 모든 키를 추출합니다.
-// 메서드 멤버와 일반 데이터 프로퍼티를 구분하는 데 사용됩니다.
 type FunctionKeys<T> = { [K in keyof T]-?: Extract<T[K], AnyFn> extends never ? never : K }[keyof T];
 
 // Strips all method keys from T, leaving only data properties.
-// T에서 모든 메서드 키를 제거하고 데이터 프로퍼티만 남깁니다.
 type NonFunctionProps<T> = Omit<T, FunctionKeys<T>>;
 
 // Readonly view of all data properties (methods excluded).
-// 모든 데이터 프로퍼티(메서드 제외)의 읽기 전용 뷰입니다.
 export type FieldsOf<T> = Readonly<NonFunctionProps<T>>;
 
 // Like FieldsOf but additionally strips keys prefixed with '_'.
 // The '_' prefix is the project convention for internal/protected fields
 // that should not be part of the public builder or of() API surface.
-// FieldsOf와 유사하지만 '_'로 시작하는 키도 추가로 제거합니다.
-// '_' 접두사는 빌더 또는 of() API에 노출되지 않아야 하는
-// 내부/보호 필드에 대한 프로젝트 컨벤션입니다.
 export type PublicFieldsOf<T> = {
   [K in keyof NonFunctionProps<T> as K extends `_${string}` ? never : K]: NonFunctionProps<T>[K];
 };

--- a/packages/jin-frame/src/validators/BaseValidator.ts
+++ b/packages/jin-frame/src/validators/BaseValidator.ts
@@ -5,9 +5,10 @@ import { runAndUnwrap } from '#tools/runAndUnwrap';
 
 export class BaseValidator<TOrigin = unknown, TData = TOrigin, TError = unknown> {
   /**
-   * exception 인 경우 validation error 발생하면 JinValidationError 예외 발생
-   * value 인 경우 validation error 발생하면 validation error 결과를 reply 데이터에 추가
-   * */
+   * Controls how a validation failure is surfaced.
+   * - 'exception': throws JinValidationError on failure
+   * - 'value': attaches the validation result to the reply object instead of throwing
+   */
   #type: ValidationResultType;
 
   constructor({ type }: { type: ValidationResultType }) {


### PR DESCRIPTION
## Summary

- **validateStatus in FrameOption**: `validateStatus` can now be set at the decorator level (`@Post`, `@Get`, etc.) and will be applied to all `_execute()` calls. Resolution priority: `_execute()` option > FrameOption decorator > default (`response.ok`).
- **safeParse fix**: `safeParse` now returns the raw string instead of `undefined` when `JSON.parse` fails, fixing plain-text (`boolean`, `string`, `number`) API responses.
- **PUT/PATCH multipart/form-data**: Extended multipart/form-data support to include PUT and PATCH methods (was POST-only).
- **Korean comment translations**: All remaining Korean source comments translated to English.
- **Naming convention docs**: Added naming convention documentation pages (EN/KO) and registered in sidebar.
- **Axios removal from docs**: Replaced all Axios references in docs with native `fetch` equivalents.
- **OAuth2 remnant removed**: Removed `refreshToken` from `AuthorizationData`.
- Version bumps: 5.0.0 → 5.0.1 → 5.0.2 → 5.0.3

## Test plan

- [x] All 482 tests passing
- [x] New tests for `validateStatus` in FrameOption (2 cases)
- [x] New tests for `safeParse` (8 cases)
- [x] New tests for PUT/PATCH multipart/form-data (2 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)