### PR TITLE
docs(jin-frame): rewrite root README.md and README.ko.md to reflect v5.x API

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -10,57 +10,46 @@
 [![codecov](https://codecov.io/gh/imjuni/jin-frame/branch/master/graph/badge.svg?style=flat-square&token=R7R2PdJcS9)](https://codecov.io/gh/imjuni/jin-frame)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
-<p align="center">
-   <img src="assets/jin-frame-brand.png" alt="brand" width="400"/>
-</p>
+**HTTP Request** = **TypeScript Class**
 
-jin-frame은 TypeScript 데코레이터와 클래스를 사용한 API 프레임워크로 API 요청을 선언적으로 작성할 수 있게 도와줍니다. 이렇게 작성한 API 요청은 재사용 가능하며 OOP 상속 구조를 사용하여 확장할 수 있습니다. 또한 Axios를 사용하여 안정성과 호환성을 확보하면서 hook, retry, mocking 등 실무에 필요한 다양한 기능을 제공합니다.
+TypeScript 데코레이터와 클래스를 사용해 HTTP 요청을 선언적으로 정의하는 라이브러리입니다. 네이티브 `fetch` 위에 구축되어 별도의 HTTP 클라이언트 의존성이 없습니다.
+
+<!-- markdownlint-disable MD033 -->
+<p align="center">
+   <img src="packages/jin-frame/assets/jin-frame-brand-icon.png" alt="brand" width="500"/>
+</p>
+<!-- markdownlint-enable MD033 -->
 
 ## Why jin-frame?
 
-1. 선언적 API 정의
-   - 클래스와 데코레이터를 사용하여 URL, Querystring, Path Parameter, Body, Header를 직관적으로 정의할 수 있습니다
-1. 타입 안정성
-   - TypeScript 타입 시스템을 사용하며, 타입 불일치를 컴파일 단계에서 검출합니다.
-1. Retry, Hook, File Upload, Mocking 지원
-   - Retry, Hook, File Upload, Mocking 등 실무에 필요한 기능을 제공합니다.
-1. Axios 에코 시스템 활용
-1. Path Parameter 지원
-   - `example.com/:id` 와 같이 URL을 통한 Path Paramter 치환을 지원합니다.
+1. **선언적 API 정의** — 클래스와 데코레이터로 URL, QueryString, Path Parameter, Body, Header를 직관적으로 정의
+2. **타입 안전성** — `ok: true | false` 판별 유니온 응답 타입, 컴파일 단계 오류 검출
+3. **Retry, Hook, File Upload, Timeout, AbortSignal 지원**
+4. **네이티브 `fetch` 기반** — 별도 HTTP 클라이언트 불필요
+5. **RFC 6570 URI Template** — `{param}` 형식의 path parameter 지원
+6. **Builder 패턴** — 컴파일 시점 필드 완전성 체크
+7. **상속 친화적** — 부모 클래스에 host/auth 정의, 자식 클래스에서 path만 오버라이드
+8. **런타임 URL 오버라이드** — `_execute()` 호출 시 host, pathPrefix, path 변경 가능
 
-## Table of Contents <!-- omit in toc -->
+## 목차 <!-- omit in toc -->
 
-- [Why jin-frame?](#why-jin-frame)
-- [Comparison of direct usage and jin-frame](#comparison-of-direct-usage-and-jin-frame)
-- [Requirements](#requirements)
-- [Install](#install)
-- [Useage](#useage)
+- [설치](#설치)
+- [버전](#버전)
+- [사용법](#사용법)
+- [데코레이터](#데코레이터)
+- [상속](#상속)
+- [Builder 패턴](#builder-패턴)
+- [Pass / Fail 응답](#pass--fail-응답)
+- [Retry, Timeout](#retry-timeout)
+- [Authorization](#authorization)
+- [validateStatus](#validatestatus)
+- [런타임 URL 오버라이드](#런타임-url-오버라이드)
+- [네이밍 컨벤션](#네이밍-컨벤션)
+- [요구사항](#요구사항)
+- [문서](#문서)
+- [License](#license)
 
-## Comparison of direct usage and jin-frame
-
-| Direct usage                        | Jin-Frame                                  |
-| ----------------------------------- | ------------------------------------------ |
-| ![axios](assets/axios-usage.png)    | ![jin-frame](assets/jinframe-usage.png)    |
-| [axios svg](assets/axios-usage.svg) | [jin-frame svg](assets/jinframe-usage.svg) |
-
-## Requirements
-
-1. TypeScript
-1. Decorator
-   - enable experimentalDecorators, emitDecoratorMetadata option in `tsconfig.json`
-
-```jsonc
-{
-  "extends": "@tsconfig/node20/tsconfig.json",
-  "compilerOptions": {
-    // enable experimentalDecorators, emitDecoratorMetadata for using decorator
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-  },
-}
-```
-
-## Install
+## 설치
 
 ```sh
 npm install jin-frame --save
@@ -74,46 +63,246 @@ yarn add jin-frame --save
 pnpm add jin-frame --save
 ```
 
-## Useage
+## 버전
+
+| 버전 | HTTP 클라이언트 | 비고 |
+|------|----------------|------|
+| < 5.0 | Axios | `axios` peer dependency 필요 |
+| >= 5.0 | 네이티브 `fetch` | HTTP 클라이언트 의존성 없음, Node.js >= 22 필요 |
+
+## 사용법
 
 ```ts
-import { Post, Param, Body, Header, Query } from 'jin-frame';
+import { Get, Param, Query, JinFrame } from 'jin-frame';
+import { randomUUID } from 'node:crypto';
 
-@Post({ host: 'http://some.api.google.com', path: '/jinframe/:passing' })
-class TestPostQuery extends JinFrame {
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/{name}',
+})
+export class PokemonFrame extends JinFrame {
   @Param()
-  public declare readonly passing: string;
+  declare public readonly name: string;
 
-  @Body({ replaceAt: 'test.hello.marvel.name' })
-  public declare readonly name: string;
+  @Query()
+  declare public readonly tid: string;
+}
 
-  @Header({ replaceAt: 'test.hello.marvel.skill' })
-  public declare readonly skill: string;
+const frame = PokemonFrame.of({ name: 'pikachu', tid: randomUUID() });
+const reply = await frame._execute();
 
-  @Body({ replaceAt: 'test.hello.marvel.gender' })
-  public declare readonly gender: string;
+if (reply.ok) {
+  console.log(reply.data);
 }
 ```
 
-이 클래스는 다음과 같은 axios 요청을 생성합니다.
+## 데코레이터
 
-```js
-{
-  timeout: 2000,
-  headers: { test: { hello: { marvel: { skill: 'beam' } } }, 'Content-Type': 'application/json' },
-  method: 'POST',
-  data: { test: { hello: { marvel: { name: 'ironman', gender: 'male' } } } },
-  transformRequest: undefined,
-  url: 'http://some.api.yanolja.com/jinframe/pass',
-  validateStatus: () => true
-}
-```
+### 메서드 데코레이터
 
-이 객체를 여러 번 생성하더라도 JinFrame은 실수를 하지 않고 언제나 올바른 객체를 생성할 것입니다. 실행하는 과정도 단순합니다. axios를 사용하기 때문에 브라우저에서도 잘 동작합니다.
+| 데코레이터 | 설명 |
+|-----------|------|
+| `@Get` | HTTP GET |
+| `@Post` | HTTP POST |
+| `@Put` | HTTP PUT |
+| `@Patch` | HTTP PATCH |
+| `@Delete` | HTTP DELETE |
+| `@Head` | HTTP HEAD |
+| `@Options` | HTTP OPTIONS |
+| `@Retry` | 재시도 설정 |
+| `@Timeout` | 요청 타임아웃 |
+| `@Dedupe` | 동일한 동시 요청 중복 제거 |
+| `@Security` | 인증 Security Provider |
+| `@Validator` | 응답 유효성 검사기 |
+
+### 필드 데코레이터
+
+| 데코레이터 | 매핑 대상 |
+|-----------|----------|
+| `@Param` | URL path parameter (`{name}`) |
+| `@Query` | URL query string |
+| `@Body` | Request body 필드 |
+| `@ObjectBody` | Request body (객체 전체 병합) |
+| `@Header` | Request header |
+| `@Cookie` | `Cookie` request header |
+
+## 상속
+
+부모 클래스에 공통 설정(host, auth, pathPrefix, 기본 필드값)을 정의하고, 자식 클래스에서 path만 오버라이드하는 패턴이 핵심입니다.
 
 ```ts
-const query = new TestPostQuery('ironman', 'beam');
-const requester = query.create();
+import { Get, Post, Param, Header, Body, JinFrame } from 'jin-frame';
+import { randomUUID } from 'node:crypto';
 
-const res = await requester();
+@Get({ host: 'https://pokeapi.co', pathPrefix: '/api/v2' })
+class PokeApiFrame extends JinFrame {
+  @Header({ replaceAt: 'X-Request-Id' })
+  declare public readonly requestId: string;
+
+  // 모든 자식 클래스에서 requestId 자동 주입
+  protected static override getDefaultValues() {
+    return { requestId: randomUUID() };
+  }
+}
+
+@Get({ path: '/pokemon/{name}' })
+class GetPokemonFrame extends PokeApiFrame {
+  @Param()
+  declare public readonly name: string;
+}
+
+@Post({ path: '/pokemon' })
+class CreatePokemonFrame extends PokeApiFrame {
+  @Body()
+  declare public readonly name: string;
+}
+
+// requestId는 getDefaultValues로 자동 설정
+const frame = GetPokemonFrame.of({ name: 'pikachu' });
+const reply = await frame._execute();
 ```
+
+## Builder 패턴
+
+`builder()`는 타입 레벨에서 설정된 필드를 추적합니다. 모든 public 필드가 할당되어야만 `build()`가 가능하며, 미입력 필드는 컴파일 에러로 검출됩니다.
+
+```ts
+const frame = PokemonFrame.builder()
+  .set('name', 'pikachu')
+  .set('tid', randomUUID())
+  .build(); // public 필드가 누락되면 컴파일 에러
+
+const reply = await frame._execute();
+```
+
+`of()`에서도 builder 콜백을 사용할 수 있습니다:
+
+```ts
+const frame = PokemonFrame.of((b) => b.set('name', 'pikachu').set('tid', randomUUID()));
+```
+
+## Pass / Fail 응답
+
+`_execute()`는 `ok`로 구분되는 판별 유니온을 반환합니다:
+
+```ts
+const reply = await frame._execute<MyFrame, Pokemon, ErrorBody>();
+
+if (reply.ok) {
+  console.log(reply.data); // Pokemon 타입
+} else {
+  console.error(reply.data); // ErrorBody 타입
+}
+```
+
+## Retry, Timeout
+
+```ts
+@Timeout(2000)
+@Retry({ max: 5, interval: 1000 })
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/{name}',
+})
+export class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+}
+```
+
+지수 백오프 예시:
+
+```ts
+@Retry({
+  max: 5,
+  getInterval: (retry) => Math.min(1000 * 2 ** retry, 30_000),
+})
+```
+
+## Authorization
+
+```ts
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/{name}',
+  authorization: process.env.YOUR_KEY_HERE,
+})
+export class PokemonFrame extends JinFrame {
+  @Param()
+  declare public readonly name: string;
+}
+```
+
+## validateStatus
+
+데코레이터 레벨에서 기본값으로 설정하거나, `_execute()` 호출 시 오버라이드할 수 있습니다:
+
+```ts
+// 데코레이터 레벨 기본값
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/{name}',
+  validateStatus: (ok, status) => ok || status === 404,
+})
+export class PokemonFrame extends JinFrame { ... }
+
+// _execute() 레벨 오버라이드 (우선 적용)
+const reply = await frame._execute({
+  validateStatus: (ok, status) => ok || status === 304,
+});
+```
+
+## 런타임 URL 오버라이드
+
+`_execute()` 호출 시 `host`, `pathPrefix`, `path`를 오버라이드할 수 있습니다:
+
+```ts
+const reply = await frame._execute({
+  host: 'https://staging.api.example.com',
+  pathPrefix: '/v3',
+  path: '/pokemon/{name}',
+});
+```
+
+## 네이밍 컨벤션
+
+| 접두사 | 용도 |
+|--------|------|
+| `#` | 내부 상태 (JavaScript private field) — 자식 클래스에서 접근 불가 |
+| `_` | 모든 인스턴스 메서드 — public API, hook, 내부 헬퍼 |
+| _(없음)_ | 정적 메서드 |
+
+전체 규칙은 [네이밍 컨벤션](https://imjuni.github.io/jin-frame/ko/method/naming-convention) 문서를 참고하세요.
+
+## 요구사항
+
+- Node.js >= 22
+- TypeScript >= 5.0
+- `tsconfig.json`에서 `experimentalDecorators`, `emitDecoratorMetadata` 활성화
+
+```jsonc
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+## 문서
+
+전체 문서: **[https://imjuni.github.io/jin-frame/ko/](https://imjuni.github.io/jin-frame/ko/)**
+
+- [시작하기](https://imjuni.github.io/jin-frame/ko/getting-to-start)
+- [상속](https://imjuni.github.io/jin-frame/ko/method/inheritance)
+- [Builder 패턴](https://imjuni.github.io/jin-frame/ko/method/builder)
+- [URL Template (RFC 6570)](https://imjuni.github.io/jin-frame/ko/method/url-template)
+- [폼 / 파일 업로드](https://imjuni.github.io/jin-frame/ko/method/form)
+- [Retry](https://imjuni.github.io/jin-frame/ko/method/retry)
+- [Authorization](https://imjuni.github.io/jin-frame/ko/method/authorization)
+- [유효성 검사](https://imjuni.github.io/jin-frame/ko/method/validation)
+- [네이밍 컨벤션](https://imjuni.github.io/jin-frame/ko/method/naming-convention)
+
+## License
+
+This software is licensed under the [MIT](LICENSE).

--- a/README.md
+++ b/README.md
@@ -10,43 +10,44 @@
 [![codecov](https://codecov.io/gh/imjuni/jin-frame/branch/master/graph/badge.svg?style=flat-square&token=R7R2PdJcS9)](https://codecov.io/gh/imjuni/jin-frame)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 
-**HTTP Reqest** = **TypeScript Class**
+**HTTP Request** = **TypeScript Class**
 
-A reusable, declarative, type-safe, and extendable HTTP request library.
+A reusable, declarative, type-safe, and extendable HTTP request library built on native `fetch`.
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
-   <img src="assets/jin-frame-brand-icon.png" alt="brand" width="500"/>
+   <img src="packages/jin-frame/assets/jin-frame-brand-icon.png" alt="brand" width="500"/>
 </p>
 <!-- markdownlint-enable MD033 -->
 
 Why `jin-frame`?
 
-1. Declarative API Definition
-2. Type Safety
-3. Support for Retry, Hooks, File Upload, Timeout and Mocking
-4. Build upon the Axios Ecosystem
-5. Path Parameter Support
+1. Declarative API Definition — HTTP requests as TypeScript classes with decorators
+2. Type Safety — discriminated union response (`ok: true | false`) with full TypeScript generics
+3. Retry, Hooks, File Upload, Timeout, and AbortSignal support
+4. Built on native `fetch` — no extra HTTP client dependency
+5. RFC 6570 URI Template path parameters (`{param}`)
+6. Builder pattern with compile-time field completeness checking
+7. Inheritance-friendly — share host/auth in a base class, override path in subclasses
+8. Runtime URL override — change host, pathPrefix, or path per `_execute()` call
 
 ## Table of Contents <!-- omit in toc -->
 
-- [Comparison of direct usage and jin-frame](#comparison-of-direct-usage-and-jin-frame)
 - [Install](#install)
+- [Version](#version)
 - [Usage](#usage)
+- [Decorators](#decorators)
+- [Inheritance](#inheritance)
+- [Builder Pattern](#builder-pattern)
+- [Pass / Fail Response](#pass--fail-response)
 - [Retry, Timeout](#retry-timeout)
 - [Authorization](#authorization)
+- [validateStatus](#validatestatus)
+- [Runtime URL Override](#runtime-url-override)
+- [Naming Convention](#naming-convention)
 - [Requirements](#requirements)
-  - [Decorator](#decorator)
-  - [Axios version](#axios-version)
-- [Example](#example)
+- [Documentation](#documentation)
 - [License](#license)
-
-## Comparison of direct usage and jin-frame
-
-| Direct usage                        | Jin-Frame                                  |
-| ----------------------------------- | ------------------------------------------ |
-| ![axios](assets/axios-usage.png)    | ![jin-frame](assets/jinframe-usage.png)    |
-| [axios svg](assets/axios-usage.svg) | [jin-frame svg](assets/jinframe-usage.svg) |
 
 ## Install
 
@@ -62,17 +63,22 @@ yarn add jin-frame --save
 pnpm add jin-frame --save
 ```
 
-## Usage
+## Version
 
-This is simple example of pokeapi.co.
+| Version | HTTP Client | Notes |
+|---------|-------------|-------|
+| < 5.0   | Axios       | Requires `axios` as a peer dependency |
+| >= 5.0  | native `fetch` | No HTTP client dependency; Node.js >= 22 required |
+
+## Usage
 
 ```ts
 import { Get, Param, Query, JinFrame } from 'jin-frame';
 import { randomUUID } from 'node:crypto';
 
-@Get({ 
+@Get({
   host: 'https://pokeapi.co',
-  path: '/api/v2/pokemon/:name',
+  path: '/api/v2/pokemon/{name}',
 })
 export class PokemonFrame extends JinFrame {
   @Param()
@@ -82,89 +88,219 @@ export class PokemonFrame extends JinFrame {
   declare public readonly tid: string;
 }
 
-(async () => {
-  const frame = PokemonFrame.of({ 
-    name: 'pikachu', 
-    tid: randomUUID(),
-  });
-  const reply = await frame.execute();
-  
-  // Show Pikachu Data
+const frame = PokemonFrame.of({ name: 'pikachu', tid: randomUUID() });
+const reply = await frame._execute();
+
+if (reply.ok) {
   console.log(reply.data);
-})();
+}
+```
+
+## Decorators
+
+### Method decorators
+
+| Decorator | Description |
+|-----------|-------------|
+| `@Get` | HTTP GET |
+| `@Post` | HTTP POST |
+| `@Put` | HTTP PUT |
+| `@Patch` | HTTP PATCH |
+| `@Delete` | HTTP DELETE |
+| `@Head` | HTTP HEAD |
+| `@Options` | HTTP OPTIONS |
+| `@Retry` | Retry configuration |
+| `@Timeout` | Request timeout |
+| `@Dedupe` | Deduplicate concurrent identical requests |
+| `@Security` | Security provider for authentication |
+| `@Validator` | Response validators |
+
+### Field decorators
+
+| Decorator | Mapped to |
+|-----------|-----------|
+| `@Param` | URL path parameter (`{name}`) |
+| `@Query` | URL query string |
+| `@Body` | Request body field |
+| `@ObjectBody` | Request body (entire object merged) |
+| `@Header` | Request header |
+| `@Cookie` | `Cookie` request header |
+
+## Inheritance
+
+Define shared settings (host, auth, pathPrefix, default field values) in a base class and override only the path in each subclass.
+
+```ts
+import { Get, Post, Param, Query, Header, Body, JinFrame } from 'jin-frame';
+import { randomUUID } from 'node:crypto';
+
+@Get({ host: 'https://pokeapi.co', pathPrefix: '/api/v2' })
+class PokeApiFrame extends JinFrame {
+  @Header({ replaceAt: 'X-Request-Id' })
+  declare public readonly requestId: string;
+
+  protected static override getDefaultValues() {
+    return { requestId: randomUUID() };
+  }
+}
+
+@Get({ path: '/pokemon/{name}' })
+class GetPokemonFrame extends PokeApiFrame {
+  @Param()
+  declare public readonly name: string;
+}
+
+@Post({ path: '/pokemon' })
+class CreatePokemonFrame extends PokeApiFrame {
+  @Body()
+  declare public readonly name: string;
+}
+
+// requestId is filled automatically by getDefaultValues
+const frame = GetPokemonFrame.of({ name: 'pikachu' });
+const reply = await frame._execute();
+```
+
+## Builder Pattern
+
+`builder()` tracks which fields have been set at the type level. `build()` is only available once all public fields are assigned, catching missing fields at compile time.
+
+```ts
+const frame = PokemonFrame.builder()
+  .set('name', 'pikachu')
+  .set('tid', randomUUID())
+  .build(); // compile error if any public field is missing
+
+const reply = await frame._execute();
+```
+
+`of()` also accepts a builder callback:
+
+```ts
+const frame = PokemonFrame.of((b) => b.set('name', 'pikachu').set('tid', randomUUID()));
+```
+
+## Pass / Fail Response
+
+`_execute()` returns a discriminated union typed by `ok`:
+
+```ts
+const reply = await frame._execute<MyFrame, Pokemon, ErrorBody>();
+
+if (reply.ok) {
+  console.log(reply.data); // typed as Pokemon
+} else {
+  console.error(reply.data); // typed as ErrorBody
+}
 ```
 
 ## Retry, Timeout
 
-Retry and Timeout can be easily applied without installing additional packages.
-
 ```ts
-import { Param, Query, Retry, Timeout, JinFrame } from 'jin-frame';
-
-@Timeout(2000) // Timeout after 2000ms
-@Retry({ max: 5, interval: 1000 }) // Retry up to 5 times with 1000ms interval
-@Get({ 
+@Timeout(2000)
+@Retry({ max: 5, interval: 1000 })
+@Get({
   host: 'https://pokeapi.co',
-  path: '/api/v2/pokemon/:name',
+  path: '/api/v2/pokemon/{name}',
 })
 export class PokemonFrame extends JinFrame {
   @Param()
   declare public readonly name: string;
-
-  @Query()
-  declare public readonly tid: string;
 }
+```
+
+`getInterval` supports exponential backoff:
+
+```ts
+@Retry({
+  max: 5,
+  getInterval: (retry) => Math.min(1000 * 2 ** retry, 30_000),
+})
 ```
 
 ## Authorization
 
 ```ts
-import { Get, Param, Query } from 'jin-frame';
-
-@Get({ 
-  host: 'https://pokeapi.co'
-  path: '/api/v2/pokemon/:name'
-  authorization: process.env.YOUR_KEY_HERE
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/{name}',
+  authorization: process.env.YOUR_KEY_HERE,
 })
 export class PokemonFrame extends JinFrame {
   @Param()
   declare public readonly name: string;
-
-  @Query()
-  declare public readonly tid: string;
 }
 ```
+
+## validateStatus
+
+`validateStatus` can be set at the decorator level or overridden per `_execute()` call:
+
+```ts
+// decorator-level default
+@Get({
+  host: 'https://pokeapi.co',
+  path: '/api/v2/pokemon/{name}',
+  validateStatus: (ok, status) => ok || status === 404,
+})
+export class PokemonFrame extends JinFrame { ... }
+
+// _execute()-level override (takes precedence)
+const reply = await frame._execute({
+  validateStatus: (ok, status) => ok || status === 304,
+});
+```
+
+## Runtime URL Override
+
+`host`, `pathPrefix`, and `path` can be overridden per `_execute()` call:
+
+```ts
+const reply = await frame._execute({
+  host: 'https://staging.api.example.com',
+  pathPrefix: '/v3',
+  path: '/pokemon/{name}',
+});
+```
+
+## Naming Convention
+
+| Prefix | Used for |
+|--------|----------|
+| `#` | Internal state (JavaScript private fields) — invisible to subclasses |
+| `_` | All instance methods — public API, hooks, and helpers |
+| _(none)_ | Static methods |
+
+See the full [Naming Convention](https://imjuni.github.io/jin-frame/method/naming-convention) documentation for details.
 
 ## Requirements
 
-### Decorator
-
-1. TypeScript
-1. Decorator
-   - enable experimentalDecorators, emitDecoratorMetadata option in `tsconfig.json`
+- Node.js >= 22
+- TypeScript >= 5.0
+- `experimentalDecorators` and `emitDecoratorMetadata` enabled in `tsconfig.json`
 
 ```jsonc
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
-    // enable experimentalDecorators, emitDecoratorMetadata for using decorator
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-  },
+    "emitDecoratorMetadata": true
+  }
 }
 ```
 
-### Axios version
+## Documentation
 
-| jin-frame | axios     |
-| --------- | --------- |
-| 2.x       | <= 0.27.x |
-| 3.x       | >= 1.1.x  |
-| 4.x       | >= 1.4.x  |
+Full documentation: **[https://imjuni.github.io/jin-frame/](https://imjuni.github.io/jin-frame/)**
 
-## Example
-
-You can find more examples in [examples directory](https://github.com/imjuni/jin-frame/tree/master/examples).
+- [Getting Started](https://imjuni.github.io/jin-frame/getting-to-start)
+- [Inheritance](https://imjuni.github.io/jin-frame/method/inheritance)
+- [Builder Pattern](https://imjuni.github.io/jin-frame/method/builder)
+- [URL Template (RFC 6570)](https://imjuni.github.io/jin-frame/method/url-template)
+- [Form / File Upload](https://imjuni.github.io/jin-frame/method/form)
+- [Retry](https://imjuni.github.io/jin-frame/method/retry)
+- [Authorization](https://imjuni.github.io/jin-frame/method/authorization)
+- [Validation](https://imjuni.github.io/jin-frame/method/validation)
+- [Naming Convention](https://imjuni.github.io/jin-frame/method/naming-convention)
 
 ## License
 


### PR DESCRIPTION
## Summary

- `README.md`, `README.ko.md` 전면 재작성 — v5.x 기준 반영
  - Axios → native `fetch` 기반으로 전환 내용 반영
  - `:param` → `{param}` URI Template 방식으로 수정
  - 버전 표, 데코레이터 표, 상속/Builder/validateStatus/런타임 URL 오버라이드 섹션 추가
  - URL Template (RFC 6570) 문서 링크 추가
  - `README.ko.md` 한국어로 전면 재작성

🤖 Generated with [Claude Code](https://claude.com/claude-code)