### PR TITLE
fix(docs): correct image path in root README.md and README.ko.md

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -16,7 +16,7 @@ TypeScript 데코레이터와 클래스를 사용해 HTTP 요청을 선언적으
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
-   <img src="packages/jin-frame/assets/jin-frame-brand-icon.png" alt="brand" width="500"/>
+   <img src="assets/jin-frame-brand-icon.png" alt="brand" width="500"/>
 </p>
 <!-- markdownlint-enable MD033 -->
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A reusable, declarative, type-safe, and extendable HTTP request library built on
 
 <!-- markdownlint-disable MD033 -->
 <p align="center">
-   <img src="packages/jin-frame/assets/jin-frame-brand-icon.png" alt="brand" width="500"/>
+   <img src="assets/jin-frame-brand-icon.png" alt="brand" width="500"/>
 </p>
 <!-- markdownlint-enable MD033 -->
 
@@ -37,6 +37,8 @@ Why `jin-frame`?
 - [Version](#version)
 - [Usage](#usage)
 - [Decorators](#decorators)
+  - [Method decorators](#method-decorators)
+  - [Field decorators](#field-decorators)
 - [Inheritance](#inheritance)
 - [Builder Pattern](#builder-pattern)
 - [Pass / Fail Response](#pass--fail-response)


### PR DESCRIPTION
## Summary

- `README.md`, `README.ko.md`의 이미지 경로 수정
  - `packages/jin-frame/assets/jin-frame-brand-icon.png` → `assets/jin-frame-brand-icon.png` (루트 기준 실제 경로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)